### PR TITLE
ROCm support

### DIFF
--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -1,0 +1,37 @@
+FROM rocm/dev-ubuntu-22.04:latest
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libsndfile1 \
+    ffmpeg \
+    python3 \
+    python3-pip \
+    python3-dev \
+    git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Set up working directory
+WORKDIR /app
+
+# Copy requirements first to leverage Docker cache
+COPY requirements-rocm.txt ./requirements.txt
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+# Copy the rest of the application code
+COPY . .
+
+# Create required directories for the application
+RUN mkdir -p model_cache reference_audio outputs voices logs \
+
+# Expose the port the application will run on (default from config, e.g., 8004)
+EXPOSE 8004
+
+# Command to run the application
+CMD ["python3", "server.py"]

--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ This server application enhances the underlying `chatterbox-tts` engine with the
     *   **NVIDIA GPU:** CUDA-compatible (Maxwell architecture or newer). Check [NVIDIA CUDA GPUs](https://developer.nvidia.com/cuda-gpus).
     *   **NVIDIA Drivers:** Latest version for your GPU/OS ([Download](https://www.nvidia.com/Download/index.aspx)).
     *   **CUDA Toolkit:** Compatible version (e.g., 11.8, 12.1+) matching the PyTorch build you install.
+    *   **AMD GPU:** ROCm-compatible. Check [AMD ROCm GPUs](https://rocm.docs.amd.com/en/latest/reference/gpu-arch-specs.html).
 *   **(Linux Only):**
     *   `libsndfile1`: Audio library needed by `soundfile`. Install via package manager (e.g., `sudo apt install libsndfile1`).
     *   `ffmpeg`: For robust audio operations (optional but recommended). Install via package manager (e.g., `sudo apt install ffmpeg`).
@@ -171,6 +172,9 @@ pip install --upgrade pip
 
 # Install project requirements
 pip install -r requirements.txt
+
+# Or if using ROCm - installs ROCm 6.4.1 version of torch, torchaudio, and pytorch-triton-rocm
+pip --pre install -r requirements-rocm.txt
 ```
 ⭐ **Note:** This installation includes large libraries like PyTorch and `chatterbox-tts`. The download and installation process may take some time depending on your internet speed and system performance.
 
@@ -380,11 +384,15 @@ This method uses `docker-compose.yml` to manage the container, volumes, and conf
     ```
 
 2.  **Review `docker-compose.yml`:**
-    *   The repository includes a `docker-compose.yml` file. Ensure it's configured for your needs (image source, ports, volumes). The provided one in this project is a good starting point.
+    *   The repository includes a `docker-compose.yml` file for CPU and NVIDIA GPU and `docker-compose-rocm.yml` for ROCm GPU. Ensure it's configured for your needs (image source, ports, volumes). The provided one in this project is a good starting point.
 
 3.  **Start the container:**
     ```bash
+    # For CPU and NVIDIA GPU
     docker compose up -d --build
+
+    # For ROCm GPU
+    docker compose -f docker-compose-rocm.yml up -d --build
     ```
     *   This command will:
         *   Build the Docker image using `Dockerfile` (if not using a pre-built image).

--- a/docker-compose-rocm.yml
+++ b/docker-compose-rocm.yml
@@ -1,0 +1,47 @@
+version: '3.8'
+
+services:
+  chatterbox-tts-server:
+    build:
+      context: .
+      dockerfile: Dockerfile.rocm
+
+    ports:
+      - "${PORT:-8004}:8004"
+    volumes:
+      # Mount local config file for persistence
+      - ./config.yaml:/app/config.yaml
+      # Mount local directories for persistent app data
+      - ./voices:/app/voices
+      - ./reference_audio:/app/reference_audio
+      - ./outputs:/app/outputs
+      - ./logs:/app/logs
+
+    # --- GPU Access ---
+    # Depending on your system setup you might need to uncomment and/or modify the line below to
+    # permit access to the image
+    ipc: host
+    privileged: true
+    security_opt:
+      - seccomp=unconfined
+    cap_add:
+      - SYS_PTRACE
+      - CAP_SYS_ADMIN
+    devices:
+      - /dev/kfd
+      - /dev/dri
+      - /dev/mem
+    group_add:
+      - video
+      - render
+      # - 993 # Add numeric render/video group id(s) if your system has different group id(s) than the image - 44(video),109(render)
+    shm_size: 8g    
+    # --- End GPU Access ---
+
+    restart: unless-stopped
+    environment:
+      # Enable faster Hugging Face downloads inside the container
+      - HF_HUB_ENABLE_HF_TRANSFER=1
+      # Make NVIDIA GPUs visible and specify capabilities for PyTorch
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility

--- a/requirements-rocm.txt
+++ b/requirements-rocm.txt
@@ -1,0 +1,32 @@
+# requirements.txt
+
+chatterbox-tts
+
+# Core Web Framework
+fastapi
+uvicorn[standard]
+
+# Machine Learning & Audio
+torch @ https://repo.radeon.com/rocm/manylinux/rocm-rel-6.4.1/torch-2.6.0%2Brocm6.4.1.git1ded221d-cp310-cp310-linux_x86_64.whl
+torchaudio @ https://repo.radeon.com/rocm/manylinux/rocm-rel-6.4.1/torchaudio-2.6.0%2Brocm6.4.1.gitd8831425-cp310-cp310-linux_x86_64.whl
+pytorch-triton-rocm @ https://repo.radeon.com/rocm/manylinux/rocm-rel-6.4.1/pytorch_triton_rocm-3.2.0%2Brocm6.4.1.git6da9e660-cp310-cp310-linux_x86_64.whl
+numpy
+soundfile # Requires libsndfile system library (e.g., sudo apt-get install libsndfile1 on Debian/Ubuntu)
+huggingface_hub
+descript-audio-codec
+safetensors
+
+# Configuration & Utilities
+pydantic
+python-dotenv # Used ONLY for initial config seeding if config.yaml missing
+Jinja2
+python-multipart # For file uploads
+requests # For health checks or other potential uses
+PyYAML # For parsing presets.yaml AND primary config.yaml
+tqdm
+
+# Audio Post-processing
+pydub
+praat-parselmouth # For unvoiced segment removal
+librosa # for changes to sampling
+hf-transfer


### PR DESCRIPTION
This pull request introduces support for AMD ROCm GPUs. 

Minor changes, really.
Addition of a ROCm-specific files for docker and python requirements.

* **ROCm Dockerfile**: Added `Dockerfile.rocm` to build a container optimized for AMD ROCm GPUs, including system dependencies, Python setup, and application configuration.
* **ROCm-specific `docker-compose` file**: Introduced `docker-compose-rocm.yml` for managing containers with ROCm GPU support, including GPU-specific configurations like device access and shared memory settings.
* **ROCm requirements file**: Added `requirements-rocm.txt` specifying ROCm-6.4.1 versions of PyTorch, torchaudio, and pytorch-triton-rocm, along with original dependencies.

### Documentation Updates:

* **Hardware requirements**: Updated `README.md` to include AMD GPU compatibility and links to ROCm GPU specifications.
* **Installation instructions**: Added ROCm-specific installation steps and commands for setting up dependencies and containers. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R175-R177) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L383-R395)

### Testing
Same as for CUDA:
```
root@8d216c31b3cf:/app# python3 -c 'import torch; print(f"PyTorch version: {torch.__version__}"); print(f"CUDA available: {torch.cuda.is_available()}"); print(f"Device name: {torch.cuda.get_device_name(0)}") if torch.cuda.is_available() else None; exit()'
PyTorch version: 2.6.0+rocm6.4.1.git1ded221d
CUDA available: True
Device name: Radeon RX 7900 XTX
```

Generation via the web UI works like a charm with the default settings.