### PR TITLE
Adding Nvidia dependencies in Dockerfile with build-arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM nvidia/cuda:12.8.1-runtime-ubuntu22.04
 
+ARG RUNTIME=nvidia
+
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
@@ -32,7 +34,12 @@ COPY requirements.txt .
 # Upgrade pip and install Python dependencies
 RUN pip3 install --no-cache-dir --upgrade pip && \
     pip3 install --no-cache-dir -r requirements.txt
+# Conditionally install NVIDIA dependencies if RUNTIME is set to 'nvidia'
+COPY requirements-nvidia.txt .
 
+RUN if [ "$RUNTIME" = "nvidia" ]; then \
+    pip3 install --no-cache-dir -r requirements-nvidia.txt; \
+    fi
 # Copy the rest of the application code
 COPY . .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ version: '3.8'
 services:
   chatterbox-tts-server:
     build:
+      args:
+      # Can be NVIDIA or cpu; Default is Nvidia
+        - RUNTIME=nvidia
       context: .
       dockerfile: Dockerfile
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   chatterbox-tts-server:
     build:
       args:
-      # Can be NVIDIA or cpu; Default is Nvidia
+      # Can be nvidia or cpu; Default is Nvidia
         - RUNTIME=nvidia
       context: .
       dockerfile: Dockerfile

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,6 +41,8 @@ python-multipart               # Form data parsing for FastAPI
 requests                       # HTTP client library
 Jinja2                        # Template engine
 aiofiles                      # Async file operations
+hf_transfer                     # Speed up file transfers with the Hugging Face Hub.
+
 
 # --- Configuration & Data Processing ---
 PyYAML                        # YAML configuration file support

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ python-multipart               # Form data parsing for FastAPI
 requests                       # HTTP client library
 Jinja2                        # Template engine
 aiofiles                      # Async file operations
-hf_transfer                     # Speed up file transfers with the Hugging Face Hub.
+# hf_transfer                     # Speed up file transfers with the Hugging Face Hub.
 
 
 # --- Configuration & Data Processing ---


### PR DESCRIPTION
Hey, when i tried to start the tts server i ran into multiple problems when running with docker:

the nvidia dependencies were not beeing installed in the Docker image that was getting built. i added a build arg to make build it with the nvidia dependencies, so the cpu inference would be possible if you would comment that out (as the docker-compose.yml was defualt with gpu support, i made it the default value in the docker-compose file.

also i couldnt download the model files without hf_transfer installed. but idk if thats a me problem, i added it commented out to the requirements.txt incase someone has the same problem. (can remove or comment it in aswell) 
hope this helps someone