### PR TITLE
Publish linux/arm64

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -53,6 +53,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           build-args: |
             RUNTIME=nvidia 


### PR DESCRIPTION
Hi there 👋,


The upstream Nvidia image is available for arm64 too.
Let's give those arm users a hand… 😉 

Best
Joe

PS: It would be cool if someone enabled the "package" tab on the GitHub repo so people could easily find the container image.