### PR TITLE
Add CUDA 12.8 support for RTX 5090 / Blackwell GPUs

### DIFF
--- a/Dockerfile.cu128
+++ b/Dockerfile.cu128
@@ -1,0 +1,73 @@
+FROM nvidia/cuda:12.8.1-runtime-ubuntu22.04
+
+ARG RUNTIME=nvidia
+
+# Set environment variables
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV DEBIAN_FRONTEND=noninteractive
+# Set the Hugging Face home directory for better model caching
+ENV HF_HOME=/app/hf_cache
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libsndfile1 \
+    ffmpeg \
+    python3 \
+    python3-pip \
+    python3-dev \
+    python3-venv \
+    git \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a symlink for python3 to be python for convenience
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+# Set up working directory
+WORKDIR /app
+
+# Upgrade pip first
+RUN pip3 install --no-cache-dir --upgrade pip
+
+# CRITICAL: Install PyTorch 2.8.0 FIRST for RTX 5090 (sm_120) support with CUDA 12.8
+# This must be done before any other packages that depend on PyTorch
+RUN if [ "$RUNTIME" = "nvidia" ]; then \
+    pip3 install --no-cache-dir \
+    --index-url https://download.pytorch.org/whl/cu128 \
+    torch==2.8.0 torchvision==0.23.0 torchaudio==2.8.0; \
+    fi
+
+# Copy requirements files
+COPY requirements.txt .
+
+# Install base dependencies (excluding PyTorch/chatterbox which are already installed or will be installed separately)
+# We need to skip torch*, chatterbox-tts, and index URLs since we're using CUDA 12.8
+RUN grep -v '^torch' requirements.txt | \
+    grep -v '^chatterbox-tts' | \
+    grep -v '^--extra-index-url' | \
+    grep -v '^#' | \
+    grep -v '^$' > /tmp/requirements-filtered.txt && \
+    pip3 install --no-cache-dir -r /tmp/requirements-filtered.txt
+
+# Install NVIDIA-specific dependencies
+# Install all chatterbox dependencies first, then install chatterbox with --no-deps
+RUN if [ "$RUNTIME" = "nvidia" ]; then \
+    pip3 install --no-cache-dir \
+    transformers diffusers resemble-perth s3tokenizer \
+    resampy omegaconf conformer && \
+    pip3 install --no-cache-dir --no-deps git+https://github.com/devnen/chatterbox.git; \
+    fi
+
+# Copy the rest of the application code
+COPY . .
+
+# Create required directories for the application
+RUN mkdir -p model_cache reference_audio outputs voices logs hf_cache
+
+# Expose the port the application will run on
+EXPOSE 8004
+
+# Command to run the application
+CMD ["python3", "server.py"]

--- a/README_CUDA128.md
+++ b/README_CUDA128.md
@@ -1,0 +1,184 @@
+# CUDA 12.8 Support for RTX 5090 and Blackwell GPUs
+
+## Overview
+
+This guide provides instructions for running Chatterbox TTS Server with **CUDA 12.8 and PyTorch 2.8.0**, which includes support for the new **RTX 5090 and Blackwell architecture (sm_120)** GPUs.
+
+## Who Needs This?
+
+Use the CUDA 12.8 configuration if you have:
+- **NVIDIA RTX 5090** or other Blackwell-based GPUs
+- CUDA compute capability **sm_120** or newer
+- CUDA 12.8+ drivers installed on your system
+
+For older GPUs (RTX 3000/4000 series, etc.), continue using the standard configuration with CUDA 12.1.
+
+## Quick Start
+
+### Using Docker Compose (Recommended)
+
+```bash
+# Clone the repository
+git clone https://github.com/devnen/Chatterbox-TTS-Server.git
+cd Chatterbox-TTS-Server
+
+# Build and start the CUDA 12.8 container
+docker compose -f docker-compose-cu128.yml up -d
+
+# View logs to confirm GPU is detected
+docker logs chatterbox-tts-server-cu128
+
+# Access the web UI
+# Open http://localhost:8004 in your browser
+```
+
+### Manual Docker Build
+
+```bash
+# Build the image
+docker build -f Dockerfile.cu128 -t chatterbox-tts-server:cu128 .
+
+# Run the container
+docker run -d \
+  --name chatterbox-tts-cu128 \
+  --gpus all \
+  -p 8004:8004 \
+  -v $(pwd)/model_cache:/app/model_cache \
+  -v $(pwd)/outputs:/app/outputs \
+  -v $(pwd)/voices:/app/voices \
+  -v ~/.cache/huggingface:/app/hf_cache \
+  chatterbox-tts-server:cu128
+```
+
+## Verification
+
+Verify that PyTorch recognizes your RTX 5090:
+
+```bash
+docker exec chatterbox-tts-server-cu128 python -c \
+  "import torch; \
+   print(f'PyTorch: {torch.__version__}'); \
+   print(f'CUDA Available: {torch.cuda.is_available()}'); \
+   print(f'GPU: {torch.cuda.get_device_name(0)}'); \
+   print(f'Supported Architectures: {torch.cuda.get_arch_list()}')"
+```
+
+Expected output should include:
+```
+PyTorch: 2.8.0+cu128
+CUDA Available: True
+GPU: NVIDIA GeForce RTX 5090
+Supported Architectures: ['sm_70', 'sm_75', 'sm_80', 'sm_86', 'sm_90', 'sm_100', 'sm_120']
+```
+
+Look for **`sm_120`** in the supported architectures list.
+
+## What's Different?
+
+The CUDA 12.8 configuration differs from the standard setup in the following ways:
+
+### 1. Dockerfile (`Dockerfile.cu128`)
+- Uses `nvidia/cuda:12.8.1-runtime-ubuntu22.04` base image
+- Installs **PyTorch 2.8.0** with CUDA 12.8 support **before** other dependencies
+- Installs chatterbox with `--no-deps` to prevent PyTorch downgrade
+
+### 2. Requirements File (`requirements-nvidia-cu128.txt`)
+- Specifies PyTorch 2.8.0 from the `cu128` wheel index
+- Documents compatibility with Blackwell architecture
+
+### 3. Docker Compose (`docker-compose-cu128.yml`)
+- Uses `Dockerfile.cu128` for building
+- Otherwise identical to standard docker-compose.yml
+
+## Prerequisites
+
+### System Requirements
+- **CUDA Drivers**: Version 570+ (supports CUDA 12.8)
+- **Docker**: With NVIDIA Container Toolkit installed
+- **GPU**: RTX 5090 or other Blackwell-based GPU
+
+### Check Your CUDA Version
+
+```bash
+nvidia-smi
+```
+
+Look for "CUDA Version" in the output - it should show 12.8 or higher.
+
+## Troubleshooting
+
+### Error: "no kernel image is available for execution"
+
+This means PyTorch doesn't support your GPU's compute capability. Verify:
+
+1. **Check PyTorch version** inside the container:
+   ```bash
+   docker exec chatterbox-tts-server-cu128 python -c "import torch; print(torch.__version__)"
+   ```
+   Should show `2.8.0+cu128`
+
+2. **Check supported architectures**:
+   ```bash
+   docker exec chatterbox-tts-server-cu128 python -c "import torch; print(torch.cuda.get_arch_list())"
+   ```
+   Should include `sm_120`
+
+### Model Loads on CPU Instead of GPU
+
+Check the server logs:
+```bash
+docker logs chatterbox-tts-server-cu128
+```
+
+Look for:
+- `Using device: cuda` (confirms GPU mode)
+- `TTS Model loaded successfully on cuda` (confirms successful GPU loading)
+
+If you see CPU usage instead, verify:
+- Docker has GPU access: `docker run --rm --gpus all nvidia/cuda:12.8.1-runtime-ubuntu22.04 nvidia-smi`
+- CUDA is available in container: See verification steps above
+
+### Slow Initial Startup
+
+The first run downloads the Chatterbox model (~3GB). This is cached in:
+- Container: `/app/hf_cache`
+- Host: `~/.cache/huggingface` (via volume mount)
+
+Subsequent starts will be much faster.
+
+## Compatibility Matrix
+
+| GPU Generation | Architecture | Compute Capability | Docker Config | PyTorch Version |
+|----------------|--------------|-------------------|---------------|-----------------|
+| RTX 5090 / Blackwell | Blackwell | sm_120 | docker-compose-cu128.yml | 2.8.0+cu128 |
+| RTX 4090 / Ada | Ada Lovelace | sm_90 | docker-compose.yml | 2.5.1+cu121 |
+| RTX 3090 / Ampere | Ampere | sm_86 | docker-compose.yml | 2.5.1+cu121 |
+| RTX 20xx / Turing | Turing | sm_75 | docker-compose.yml | 2.5.1+cu121 |
+
+## Performance Notes
+
+- **VRAM Usage**: Expect ~8-10GB VRAM usage for the model
+- **Generation Speed**: RTX 5090 provides significantly faster generation than previous generations
+- **First Generation**: May be slower due to JIT compilation; subsequent generations are faster
+
+## Additional Resources
+
+- [PyTorch CUDA 12.8 Documentation](https://pytorch.org/get-started/locally/)
+- [NVIDIA CUDA Toolkit](https://developer.nvidia.com/cuda-downloads)
+- [Docker NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html)
+
+## Downgrading to Standard CUDA 12.1
+
+If you need to switch back to the standard configuration:
+
+```bash
+# Stop and remove CUDA 12.8 container
+docker compose -f docker-compose-cu128.yml down
+
+# Start standard CUDA 12.1 container
+docker compose up -d
+```
+
+## Contributing
+
+Found an issue with CUDA 12.8 support? Please [open an issue](https://github.com/devnen/Chatterbox-TTS-Server/issues) or submit a pull request.

--- a/README_PR_CHANGES.md
+++ b/README_PR_CHANGES.md
@@ -1,0 +1,60 @@
+# Suggested README Addition for CUDA 12.8 Support
+
+## Insert this section after "Option 2: NVIDIA GPU Installation (CUDA)" (around line 220)
+
+```markdown
+---
+
+### **Option 2b: NVIDIA GPU with CUDA 12.8 (RTX 5090 / Blackwell)**
+
+> **Note:** Only use this if you have an **RTX 5090** or other **Blackwell-based GPU**. For RTX 3000/4000 series, use Option 2 above.
+
+For users with the latest NVIDIA RTX 5090 or other Blackwell architecture GPUs that require CUDA 12.8 and sm_120 support.
+
+**Prerequisites:**
+- NVIDIA RTX 5090 or Blackwell-based GPU
+- CUDA 12.8+ drivers (driver version 570+)
+
+**Using Docker (Recommended for RTX 5090):**
+```bash
+# Build and start with CUDA 12.8 support
+docker compose -f docker-compose-cu128.yml up -d
+
+# Access the web UI at http://localhost:8004
+```
+
+**Manual Installation:**
+```bash
+# Make sure your (venv) is active
+pip install --upgrade pip
+pip install -r requirements-nvidia-cu128.txt
+pip install --no-deps git+https://github.com/devnen/chatterbox.git
+```
+
+**After installation, verify that PyTorch supports sm_120:**
+```bash
+python -c "import torch; print(f'PyTorch: {torch.__version__}'); print(f'CUDA: {torch.cuda.is_available()}'); print(f'GPU: {torch.cuda.get_device_name(0)}'); print(f'Architectures: {torch.cuda.get_arch_list()}')"
+```
+
+You should see `sm_120` in the architectures list!
+
+<details>
+<summary><strong>💡 Why CUDA 12.8?</strong></summary>
+
+The RTX 5090 uses NVIDIA's new **Blackwell architecture** with compute capability **sm_120**. PyTorch 2.8.0 with CUDA 12.8 is the first stable release that includes support for this architecture. Earlier versions (including CUDA 12.1) will fail with the error: `CUDA error: no kernel image is available for execution on the device`.
+
+See [README_CUDA128.md](README_CUDA128.md) for detailed setup instructions and troubleshooting.
+</details>
+```
+
+## Additional file to create
+
+Add this note to the Docker section (around line 290-300):
+
+```markdown
+**For RTX 5090 / Blackwell GPUs:** Use the CUDA 12.8 configuration:
+```bash
+docker compose -f docker-compose-cu128.yml up -d
+```
+See [README_CUDA128.md](README_CUDA128.md) for details.
+```

--- a/docker-compose-cu128.yml
+++ b/docker-compose-cu128.yml
@@ -1,0 +1,30 @@
+services:
+  chatterbox-tts-server:
+    build:
+      context: .
+      dockerfile: Dockerfile.cu128
+      args:
+        RUNTIME: nvidia
+    image: chatterbox-tts-server:cu128
+    container_name: chatterbox-tts-server-cu128
+    ports:
+      - "8004:8004"
+    volumes:
+      - ./model_cache:/app/model_cache
+      - ./reference_audio:/app/reference_audio
+      - ./outputs:/app/outputs
+      - ./voices:/app/voices
+      - ./logs:/app/logs
+      - ./config.yaml:/app/config.yaml
+      - ~/.cache/huggingface:/app/hf_cache
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    restart: unless-stopped

--- a/requirements-nvidia-cu128.txt
+++ b/requirements-nvidia-cu128.txt
@@ -1,0 +1,20 @@
+# requirements-nvidia-cu128.txt (For NVIDIA GPU Installation with CUDA 12.8)
+# This file provides CUDA 12.8 support including RTX 5090 / Blackwell architecture (sm_120)
+# Use this file if you have:
+# - RTX 5090 or other Blackwell GPUs
+# - CUDA 12.8+ drivers installed
+# - Need for latest PyTorch features
+
+# Use the official PyTorch package index for CUDA 12.8
+--extra-index-url https://download.pytorch.org/whl/cu128
+
+# PyTorch 2.8.0 with CUDA 12.8 - includes sm_120 (Blackwell) support
+torch==2.8.0
+torchvision==0.23.0
+torchaudio==2.8.0
+
+# --- Core Application Dependencies ---
+
+# Chatterbox TTS and dependencies
+# Note: Install this separately with --no-deps to prevent PyTorch downgrade
+# pip install --no-deps git+https://github.com/devnen/chatterbox.git


### PR DESCRIPTION
# Pull Request: Add CUDA 12.8 Support for RTX 5090 / Blackwell GPUs

## Summary

This PR adds support for NVIDIA's RTX 5090 and Blackwell architecture GPUs (sm_120 compute capability) while maintaining full backward compatibility with existing CUDA 12.1 configurations.

## Problem

The RTX 5090 uses the new Blackwell architecture with CUDA compute capability `sm_120`. Current stable PyTorch releases with CUDA 12.1 do not support sm_120, causing the error:

```
CUDA error: no kernel image is available for execution on the device
```

## Solution

PyTorch 2.8.0 with CUDA 12.8 is the first stable release to include sm_120 support. This PR provides an **additional** configuration option for users with Blackwell GPUs while keeping the existing CUDA 12.1 setup as the default.

## Changes

### New Files Added

1. **`Dockerfile.cu128`** - Alternative Dockerfile with CUDA 12.8 support
   - Uses `nvidia/cuda:12.8.1-runtime-ubuntu22.04` base image
   - Installs PyTorch 2.8.0+cu128 before other dependencies to prevent downgrade
   - Installs chatterbox with `--no-deps` to maintain PyTorch version

2. **`docker-compose-cu128.yml`** - Docker Compose configuration for CUDA 12.8
   - Uses `Dockerfile.cu128`
   - Otherwise identical to standard docker-compose.yml

3. **`requirements-nvidia-cu128.txt`** - CUDA 12.8 Python requirements
   - Specifies PyTorch 2.8.0 from cu128 wheel index
   - Documents compatibility with Blackwell architecture

4. **`README_CUDA128.md`** - Complete setup guide for CUDA 12.8
   - Quick start instructions
   - Verification steps
   - Troubleshooting guide
   - Compatibility matrix

5. **`README_PR_CHANGES.md`** - Suggested additions to main README

### Files Modified

**None** - This PR is 100% backward compatible and adds files only.

## Backward Compatibility

✅ **Fully backward compatible** - No existing files are modified:
- Default `Dockerfile` remains unchanged (CUDA 12.1)
- Default `docker-compose.yml` remains unchanged
- All existing requirements files unchanged
- Existing users are completely unaffected

## Usage

### For RTX 5090 / Blackwell Users

```bash
# Using Docker Compose (Recommended)
docker compose -f docker-compose-cu128.yml up -d

# Or manual pip installation
pip install -r requirements-nvidia-cu128.txt
pip install --no-deps git+https://github.com/devnen/chatterbox.git
```

### For All Other Users

Continue using the standard setup - **no changes needed**:

```bash
docker compose up -d
# or
pip install -r requirements-nvidia.txt
```

## Verification

Users can verify sm_120 support with:

```bash
docker exec <container> python -c "import torch; print(torch.cuda.get_arch_list())"
```

Expected output should include: `['sm_70', 'sm_75', 'sm_80', 'sm_86', 'sm_90', 'sm_100', 'sm_120']`

## Benefits

1. **RTX 5090 Support** - Enables use of latest NVIDIA hardware
2. **Future-Proof** - Supports all future Blackwell-based GPUs
3. **Latest PyTorch** - Users benefit from PyTorch 2.8.0 improvements
4. **No Breaking Changes** - Existing users unaffected
5. **Clear Documentation** - Comprehensive setup guide included

## Testing

Tested on:
- RTX 5090 with CUDA 12.8.1 drivers (version 570.133.07)
- PyTorch 2.8.0+cu128
- Ubuntu 22.04 host system
- Docker 27.x with NVIDIA Container Toolkit

Verified:
- ✅ Model loads successfully on GPU
- ✅ CUDA kernel execution works (no sm_120 errors)
- ✅ All dependencies install without conflicts
- ✅ Server runs and generates audio correctly
- ✅ Web UI accessible and functional

## Compatibility Matrix

| GPU Generation | Architecture | Compute Capability | Configuration | PyTorch |
|----------------|--------------|-------------------|---------------|---------|
| RTX 5090 / Blackwell | Blackwell | sm_120 | docker-compose-cu128.yml | 2.8.0+cu128 |
| RTX 4090 / Ada | Ada Lovelace | sm_90 | docker-compose.yml | 2.5.1+cu121 |
| RTX 3090 / Ampere | Ampere | sm_86 | docker-compose.yml | 2.5.1+cu121 |
| RTX 20xx / Turing | Turing | sm_75 | docker-compose.yml | 2.5.1+cu121 |

## Documentation Updates

Optional README additions provided in `README_PR_CHANGES.md`:
- Brief mention of CUDA 12.8 option in installation section
- Link to detailed README_CUDA128.md guide
- Note in Docker section about cu128 variant

These can be applied or modified as preferred by the maintainer.

## Dependencies

All new dependencies are identical to existing ones, just different versions:
- PyTorch: 2.8.0 (vs 2.5.1)
- CUDA: 12.8 (vs 12.1)
- Base image: cuda:12.8.1-runtime (vs cuda:12.6.2-runtime)

## Open Question for Maintainer

1. **README updates**: Apply suggested changes or keep as separate file?

## Checklist

- [x] Code follows project style
- [x] Backward compatible (no breaking changes)
- [x] Documentation provided (README_CUDA128.md)
- [x] Tested on target hardware (RTX 5090)
- [x] All new files included
- [x] Docker configurations tested

## Related Links

- [PyTorch 2.8.0 Release Notes](https://github.com/pytorch/pytorch/releases/tag/v2.8.0)
- [CUDA 12.8 Documentation](https://docs.nvidia.com/cuda/archive/12.8.0/)
- [RTX 5090 Specifications](https://www.nvidia.com/en-us/geforce/graphics-cards/50-series/)
