### PR TITLE
feat: allow serving over HTTPS

### DIFF
--- a/config.py
+++ b/config.py
@@ -47,6 +47,8 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         ),  # Path to the server log file.
         "log_file_max_size_mb": 10,  # Maximum size of a single log file before rotation.
         "log_file_backup_count": 5,  # Number of backup log files to keep.
+        "ssl_certfile": None,
+        "ssl_keyfile": None
     },
     "model": {  # Added section for model source configuration
         "repo_id": "chatterbox-turbo",  # UPDATED: Default to Turbo model
@@ -213,7 +215,7 @@ class YamlConfigManager:
 
         # Convert relevant string paths to Path objects.
         path_key_map_for_conversion = {
-            "server": ["log_file_path"],
+            "server": ["log_file_path", "ssl_certfile", "ssl_keyfile"],
             "tts_engine": ["predefined_voices_path", "reference_audio_path"],
             "paths": ["model_cache", "output"],
         }
@@ -276,7 +278,7 @@ class YamlConfigManager:
         """
         config_copy_for_saving = deepcopy(config_dict)
         path_key_map_for_conversion = {
-            "server": ["log_file_path"],
+            "server": ["log_file_path", "ssl_certfile", "ssl_keyfile"],
             "tts_engine": ["predefined_voices_path", "reference_audio_path"],
             "paths": ["model_cache", "output"],
         }
@@ -720,6 +722,13 @@ def get_port() -> int:
     """Returns the server port number."""
     return config_manager.get_int(
         "server.port", _get_default_from_structure("server.port")
+    )
+
+
+def get_ssl() -> (Path, Path):
+    return (
+        config_manager.get_path("server.ssl_certfile", _get_default_from_structure("server.ssl_certfile")),
+        config_manager.get_path("server.ssl_keyfile", _get_default_from_structure("server.ssl_keyfile")),
     )
 
 

--- a/server.py
+++ b/server.py
@@ -43,6 +43,7 @@ from config import (
     config_manager,
     get_host,
     get_port,
+    get_ssl,
     get_log_file_path,
     get_output_path,
     get_reference_audio_path,
@@ -1335,6 +1336,7 @@ async def openai_speech_endpoint(request: OpenAISpeechRequest):
 if __name__ == "__main__":
     server_host = get_host()
     server_port = get_port()
+    ssl_certfile, ssl_keyfile = get_ssl()
 
     logger.info(f"Starting TTS Server directly on http://{server_host}:{server_port}")
     logger.info(
@@ -1351,4 +1353,6 @@ if __name__ == "__main__":
         log_level="info",
         workers=1,
         reload=False,
+        ssl_certfile=ssl_certfile,
+        ssl_keyfile=ssl_keyfile,
     )


### PR DESCRIPTION
TODO:
- [ ] update links in log output to use correct protocol
- [ ] fixes for non-SSL configurations (at the moment it defaults to a value of `.` for the certfile and keyfile)