### PR TITLE
Add dynamic multilingual support to language selector

### DIFF
--- a/server.py
+++ b/server.py
@@ -945,6 +945,11 @@ async def custom_tts_endpoint(
                 seed=(
                     request.seed if request.seed is not None else get_gen_default_seed()
                 ),
+                language=(
+                    request.language
+                    if request.language is not None
+                    else get_gen_default_language()
+                ),
             )
             perf_monitor.record(f"Engine synthesized chunk {i+1}")
 
@@ -1257,6 +1262,7 @@ async def openai_speech_endpoint(request: OpenAISpeechRequest):
             exaggeration=get_gen_default_exaggeration(),
             cfg_weight=get_gen_default_cfg_weight(),
             seed=seed_to_use,
+            language=get_gen_default_language(),
         )
 
         if audio_tensor is None or sr is None:

--- a/ui/index.html
+++ b/ui/index.html
@@ -63,8 +63,9 @@
                                     <div class="form-group inline">
                                         <label for="model-select" class="form-label">Active Model:</label>
                                         <select id="model-select" name="model_selector" class="form-select wide">
-                                            <option value="chatterbox-turbo">Chatterbox Turbo (Fast)</option>
-                                            <option value="chatterbox">Chatterbox Original</option>
+                                            <option value="chatterbox-turbo">Chatterbox Turbo (Fast, English)</option>
+                                            <option value="chatterbox">Chatterbox Original (English)</option>
+                                            <option value="chatterbox-multilingual">Chatterbox Multilingual (23 Languages)</option>
                                         </select>
                                     </div>
                                     <div id="model-status" class="model-status">


### PR DESCRIPTION
## Summary

This PR adds full support for the **ChatterboxMultilingualTTS** model, enabling text-to-speech generation in 23 languages.

### Features
- Add ChatterboxMultilingualTTS as a selectable model in the UI
- Implement dynamic language selector that shows all 23 languages only when Multilingual model is active
- Pass language parameter through the entire pipeline to the TTS engine
- Preserve user language selection when switching between models

### Supported Languages
Arabic, Chinese, Danish, Dutch, English, Finnish, French, German, Greek, Hebrew, Hindi, Italian, Japanese, Korean, Malay, Norwegian, Polish, Portuguese, Russian, Spanish, Swahili, Swedish, Turkish

## Changes

### Backend (`engine.py`)
- Import `ChatterboxMultilingualTTS` and `SUPPORTED_LANGUAGES` from chatterbox
- Add `multilingual` model type to `MODEL_SELECTOR_MAP`
- Update `_get_model_class()` to handle multilingual model selection
- Update `get_model_info()` to expose multilingual capabilities and supported languages
- Add `language` parameter to `synthesize()` function
- Pass `language_id` to multilingual model `generate()` method

### Backend (`server.py`)
- Pass `language` parameter to both `engine.synthesize()` calls
- Use `get_gen_default_language()` as fallback for default language

### Frontend (`ui/index.html`)
- Add "Chatterbox Multilingual (23 Languages)" option to model selector
- Update existing model labels to clarify language support
- Add all 23 language options to the language dropdown (with native script names)

### Frontend (`ui/script.js`)
- Rename language constants to `LANGUAGES_MULTILINGUAL` and `LANGUAGES_ENGLISH_ONLY`
- Update `updateLanguageOptions()` to show/hide language selector based on model type
- Show language dropdown only when Multilingual model is selected
- Update model badge to display multilingual indicator
- Fix model selector value mapping for all three model types (original, turbo, multilingual)
- Preserve language selection when switching away from Multilingual model

## API Compatibility

All changes are backward compatible:
- `synthesize()` function has `language="en"` as default parameter
- Original and Turbo models ignore the language parameter
- Existing API endpoints continue to work without modification
- `/api/model-info` now includes `supports_multilingual` and `supported_languages` fields

## Test Plan

- [ ] Start server with default config - verify Turbo model loads
- [ ] Switch to Multilingual model via UI - verify model loads and language dropdown appears
- [ ] Select Italian, generate TTS with Italian text - verify Italian pronunciation
- [ ] Switch to Turbo model - verify language dropdown hides
- [ ] Switch back to Multilingual - verify Italian is restored as selected language
- [ ] Test `/tts` API endpoint with `language` parameter
- [ ] Test `/v1/audio/speech` endpoint - verify it still works (uses default language)
- [ ] Test `/api/model-info` - verify it returns `supported_languages` for multilingual model