### PR TITLE
Fix error serialization in frontend notifications

### DIFF
--- a/ui/script.js
+++ b/ui/script.js
@@ -168,6 +168,13 @@ document.addEventListener('DOMContentLoaded', async function () {
     }
 
     // --- Utility Functions ---
+    function formatErrorDetail(detail) {
+        if (typeof detail === 'string') return detail;
+        if (Array.isArray(detail)) return detail.map(e => e.msg || JSON.stringify(e)).join('; ');
+        if (detail && typeof detail === 'object') return JSON.stringify(detail);
+        return String(detail);
+    }
+
     function showNotification(message, type = 'info', duration = 5000) {
         if (!notificationArea) return null;
 
@@ -270,7 +277,7 @@ document.addEventListener('DOMContentLoaded', async function () {
             });
             if (!response.ok) {
                 const errorResult = await response.json();
-                throw new Error(errorResult.detail || `Failed to save UI state (status ${response.status})`);
+                throw new Error(formatErrorDetail(errorResult.detail) || `Failed to save UI state (status ${response.status})`);
             }
         } catch (error) {
             console.error("Error saving UI state via API:", error);
@@ -526,7 +533,7 @@ document.addEventListener('DOMContentLoaded', async function () {
 
             if (!response.ok) {
                 const errorResult = await response.json().catch(() => ({ detail: 'Failed to save' }));
-                throw new Error(errorResult.detail || 'Failed to save model configuration');
+                throw new Error(formatErrorDetail(errorResult.detail) || 'Failed to save model configuration');
             }
 
             showNotification('Model configuration saved. Initiating server restart...', 'info');
@@ -1085,7 +1092,7 @@ document.addEventListener('DOMContentLoaded', async function () {
             });
             if (!response.ok) {
                 const errorResult = await response.json().catch(() => ({ detail: `HTTP error ${response.status}` }));
-                throw new Error(errorResult.detail || 'TTS generation failed.');
+                throw new Error(formatErrorDetail(errorResult.detail) || 'TTS generation failed.');
             }
             const audioBlob = await response.blob();
             const endTime = performance.now();
@@ -1331,7 +1338,7 @@ document.addEventListener('DOMContentLoaded', async function () {
                 });
                 if (!response.ok) {
                     const errorResult = await response.json().catch(() => ({ detail: 'Failed to reset settings on server.' }));
-                    throw new Error(errorResult.detail);
+                    throw new Error(formatErrorDetail(errorResult.detail));
                 }
                 const result = await response.json();
                 updateConfigStatus(resetSettingsBtn, configStatus, result.message + " Reloading page...", 'success', 0, false);


### PR DESCRIPTION
## Summary

Fixes frontend displaying `[object Object]` instead of actual error messages when the backend returns validation errors.

## Problem

When the backend returns a Pydantic validation error (HTTP 422), the `detail` field is an **array of objects**, not a string:

```json
{
  "detail": [
    {
      "type": "less_than_equal",
      "loc": ["body", "chunk_size"],
      "msg": "Input should be less than or equal to 500",
      "input": 510
    }
  ]
}
```

The frontend passed `errorResult.detail` directly to `new Error()`, which called `.toString()` on the array and displayed **"[object Object]"** to the user.

### Steps to reproduce
1. Enable text splitting in the UI
2. Set the chunk size slider to a value above 500 (e.g. 510)
3. Click "Generate Speech"
4. Observe `[object Object]` in the error notification

## Solution

Added a `formatErrorDetail()` utility function that handles all API error response formats:

- **String** (standard `HTTPException`): returned as-is
- **Array** (Pydantic 422 validation errors): extracts the `.msg` field from each entry and joins them with `"; "`
- **Object** (unexpected format): falls back to `JSON.stringify()`

Applied to all 4 error handling paths in `script.js`:
- UI state save errors
- Model configuration errors  
- TTS generation errors
- Settings reset errors

### After fix
The error notification now correctly displays: *"Input should be less than or equal to 500"*

## Test Plan

- [ ] Set chunk size > 500, generate speech → verify readable error message appears
- [ ] Trigger a standard server error (e.g. no voice selected) → verify error still displays correctly
- [ ] Save settings with invalid values → verify error message is readable