### PR TITLE
fix: prevent path traversal in voice file parameters (CWE-22)

### DIFF
--- a/server.py
+++ b/server.py
@@ -880,7 +880,13 @@ async def custom_tts_endpoint(
                 detail="Missing 'predefined_voice_id' for 'predefined' voice mode.",
             )
         voices_dir = get_predefined_voices_path(ensure_absolute=True)
-        potential_path = voices_dir / request.predefined_voice_id
+        try:
+            potential_path = utils.validate_safe_path(voices_dir, request.predefined_voice_id)
+        except ValueError:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid predefined voice filename: '{request.predefined_voice_id}'.",
+            )
         if not potential_path.is_file():
             logger.error(f"Predefined voice file not found: {potential_path}")
             raise HTTPException(
@@ -897,7 +903,13 @@ async def custom_tts_endpoint(
                 detail="Missing 'reference_audio_filename' for 'clone' voice mode.",
             )
         ref_dir = get_reference_audio_path(ensure_absolute=True)
-        potential_path = ref_dir / request.reference_audio_filename
+        try:
+            potential_path = utils.validate_safe_path(ref_dir, request.reference_audio_filename)
+        except ValueError:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid reference audio filename: '{request.reference_audio_filename}'.",
+            )
         if not potential_path.is_file():
             logger.error(
                 f"Reference audio file for cloning not found: {potential_path}"
@@ -1275,8 +1287,20 @@ async def openai_speech_endpoint(request: OpenAISpeechRequest):
     # Determine the audio prompt path based on the voice parameter
     predefined_voices_path = get_predefined_voices_path(ensure_absolute=True)
     reference_audio_path = get_reference_audio_path(ensure_absolute=True)
-    voice_path_predefined = predefined_voices_path / request.voice
-    voice_path_reference = reference_audio_path / request.voice
+    try:
+        voice_path_predefined = utils.validate_safe_path(predefined_voices_path, request.voice)
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid voice filename: '{request.voice}'.",
+        )
+    try:
+        voice_path_reference = utils.validate_safe_path(reference_audio_path, request.voice)
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid voice filename: '{request.voice}'.",
+        )
 
     if voice_path_predefined.is_file():
         audio_prompt_path = voice_path_predefined

--- a/utils.py
+++ b/utils.py
@@ -57,6 +57,27 @@ except ImportError:
 
 
 # --- Filename Sanitization ---
+
+def validate_safe_path(base_dir: Path, filename: str) -> Path:
+    """
+    Validate that a user-supplied filename resolves to a path within base_dir.
+    Raises ValueError if the resolved path escapes the base directory.
+    """
+    if not filename:
+        raise ValueError("Filename must not be empty.")
+    # Reject any path separators (both Unix and Windows style)
+    if '/' in filename or '\\' in filename:
+        raise ValueError(f"Invalid filename: {filename!r}")
+    # Use only the basename to strip any directory components
+    safe_name = Path(filename).name
+    if not safe_name or safe_name != filename or safe_name in ('.', '..'):
+        raise ValueError(f"Invalid filename: {filename!r}")
+    resolved = (base_dir / safe_name).resolve()
+    base_resolved = base_dir.resolve()
+    if not str(resolved).startswith(str(base_resolved) + os.sep) and resolved != base_resolved:
+        raise ValueError(f"Path escapes base directory: {filename!r}")
+    return resolved
+
 def sanitize_filename(filename: str) -> str:
     """
     Removes potentially unsafe characters and path components from a filename


### PR DESCRIPTION
## Vulnerability Summary

**CWE-22: Improper Limitation of a Pathname to a Restricted Directory (Path Traversal)**
**Severity:** High

### Data Flow

Three user-controlled parameters are joined directly to base directory paths without traversal validation:

1. **`predefined_voice_id`** (POST `/tts`, `voice_mode=predefined`) → `voices_dir / request.predefined_voice_id` (server.py L883)
2. **`reference_audio_filename`** (POST `/tts`, `voice_mode=clone`) → `ref_dir / request.reference_audio_filename` (server.py L900)
3. **`voice`** (POST `/v1/audio/speech`) → `predefined_voices_path / request.voice` and `reference_audio_path / request.voice` (server.py L1278-1279)

An attacker can supply values like `../../etc/passwd` to escape the intended directory. The subsequent `.is_file()` check resolves the traversal and acts as an **arbitrary file existence oracle**. If the file exists and is valid audio, it may also be processed through the TTS engine.

### Preconditions

- Network access to the server (binds `0.0.0.0`, no authentication, CORS `*`)

### Exploit Example

```bash
# File existence oracle: 404 = not found, 500 = exists but invalid audio
curl -X POST http://target:8004/tts -H "Content-Type: application/json" \
  -d "{\"text\":\"hello\",\"voice_mode\":\"predefined\",\"predefined_voice_id\":\"../../etc/passwd\"}"
```

---

## Fix Description

Added a `validate_safe_path(base_dir, filename)` function in `utils.py` that:

1. **Rejects path separators** (`/`, `\\`) in the filename
2. **Extracts basename** and verifies it matches the original input
3. **Resolves the full path** and confirms it remains within the base directory

All three vulnerable path constructions in `server.py` now call this function, raising a 400 error for invalid filenames.

### Rationale

- Defense-in-depth: the separator check catches obvious attacks, while `resolve()` + prefix check catches edge cases (symlinks, encoding tricks)
- Minimal change: only the path construction is modified; all downstream logic unchanged
- No new dependencies

---

## Test Results

**Files changed:** `server.py` (28 added, 4 removed), `utils.py` (21 added)

Manual verification:
- `validate_safe_path(Path("/app/voices"), "voice1.wav")` → `/app/voices/voice1.wav` ✓
- `validate_safe_path(Path("/app/voices"), "../../etc/passwd")` → `ValueError` ✓
- `validate_safe_path(Path("/app/voices"), "../secret.wav")` → `ValueError` ✓
- `validate_safe_path(Path("/app/voices"), "")` → `ValueError` ✓
- `validate_safe_path(Path("/app/voices"), "subdir/file.wav")` → `ValueError` ✓

---

## Disprove Analysis

We attempted to invalidate this finding across multiple dimensions:

| Check | Result |
|-------|--------|
| **Authentication** | None. Any network client can call these endpoints. |
| **Network binding** | `0.0.0.0` with CORS `*`. Fully network-accessible. |
| **Deployment restrictions** | No Dockerfile or k8s manifests restricting access. |
| **Input validation** | No validation before the vulnerable path join. |
| **Precondition equivalence** | Network access ≠ file system access. The traversal grants **additional capability** beyond what preconditions provide. |
| **Mitigations** | `.is_file()` prevents crashes but does not prevent traversal — it enables a file existence oracle. |

**Verdict: CONFIRMED_VALID** — the vulnerability is exploitable and the fix is correct and comprehensive.
