### PR TITLE
Fix path traversal in /tts and /v1/audio/speech voice/filename parameters

### DIFF
--- a/server.py
+++ b/server.py
@@ -880,7 +880,10 @@ async def custom_tts_endpoint(
                 detail="Missing 'predefined_voice_id' for 'predefined' voice mode.",
             )
         voices_dir = get_predefined_voices_path(ensure_absolute=True)
-        potential_path = voices_dir / request.predefined_voice_id
+        try:
+            potential_path = utils.safe_resolve_within(voices_dir, request.predefined_voice_id)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid predefined voice ID.")
         if not potential_path.is_file():
             logger.error(f"Predefined voice file not found: {potential_path}")
             raise HTTPException(
@@ -897,7 +900,10 @@ async def custom_tts_endpoint(
                 detail="Missing 'reference_audio_filename' for 'clone' voice mode.",
             )
         ref_dir = get_reference_audio_path(ensure_absolute=True)
-        potential_path = ref_dir / request.reference_audio_filename
+        try:
+            potential_path = utils.safe_resolve_within(ref_dir, request.reference_audio_filename)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid reference audio filename.")
         if not potential_path.is_file():
             logger.error(
                 f"Reference audio file for cloning not found: {potential_path}"
@@ -1275,8 +1281,11 @@ async def openai_speech_endpoint(request: OpenAISpeechRequest):
     # Determine the audio prompt path based on the voice parameter
     predefined_voices_path = get_predefined_voices_path(ensure_absolute=True)
     reference_audio_path = get_reference_audio_path(ensure_absolute=True)
-    voice_path_predefined = predefined_voices_path / request.voice
-    voice_path_reference = reference_audio_path / request.voice
+    try:
+        voice_path_predefined = utils.safe_resolve_within(predefined_voices_path, request.voice)
+        voice_path_reference = utils.safe_resolve_within(reference_audio_path, request.voice)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid voice parameter.")
 
     if voice_path_predefined.is_file():
         audio_prompt_path = voice_path_predefined

--- a/utils.py
+++ b/utils.py
@@ -1293,3 +1293,29 @@ class PerformanceMonitor:
         if self.logger:
             self.logger.log(log_level, full_report_str)
         return full_report_str
+
+
+def safe_resolve_within(base_dir: Path, filename: str) -> Path:
+    """
+    Safely resolve a user-supplied filename within a base directory.
+    Prevents path traversal by ensuring the resolved path stays within base_dir.
+
+    Args:
+        base_dir: The trusted base directory.
+        filename: The user-supplied filename (should be a plain filename, not a path).
+
+    Returns:
+        The resolved Path within base_dir.
+
+    Raises:
+        ValueError: If the resolved path escapes the base directory.
+    """
+    # Strip any directory components — only use the basename
+    safe_name = Path(filename).name
+    if not safe_name:
+        raise ValueError("Invalid filename: empty after sanitization.")
+    resolved = (base_dir / safe_name).resolve()
+    base_resolved = base_dir.resolve()
+    if not str(resolved).startswith(str(base_resolved) + os.sep) and resolved != base_resolved:
+        raise ValueError(f"Path traversal detected: '{filename}' resolves outside the allowed directory.")
+    return resolved


### PR DESCRIPTION
## Summary

This PR hardens three endpoints against path traversal (CWE-22) where user-supplied filenames are joined to base directories without validation.

## Affected code

In `server.py`:

- `custom_tts_endpoint` (`/tts`) — `request.predefined_voice_id` joined to the predefined voices directory.
- `custom_tts_endpoint` (`/tts`) — `request.reference_audio_filename` joined to the reference audio directory.
- `openai_speech_endpoint` (`/v1/audio/speech`) — `request.voice` joined to both the predefined voices and reference audio directories.

In each case the previous code was effectively `base_dir / user_input`, which permits inputs such as `../../etc/passwd` to escape the intended directory. The resulting path was then passed to `Path.is_file()` and, on a hit, loaded by the TTS engine as an audio prompt. Both endpoints are reachable without authentication, and the server defaults to binding `0.0.0.0`.

## Impact

An attacker with network access to the service can:

1. Probe for the existence of arbitrary files on the host filesystem by observing whether the endpoint returns a 404 ("file not found") versus continuing past the `is_file()` check.
2. Cause arbitrary local files (anything readable by the server process) to be opened by the audio loader. Depending on the file, this can result in errors, resource exhaustion, or partial content disclosure via error messages.

The endpoints have no authentication, so the only precondition is HTTP reachability — which by itself does not grant filesystem read access. The traversal therefore provides genuine new capability beyond what an unauthenticated network user already has.

## Fix

Adds a small helper `safe_resolve_within(base_dir, filename)` in `utils.py` that:

1. Reduces the input to its basename via `Path(filename).name`, stripping any directory components (`../`, absolute paths, backslashes on Windows).
2. Resolves the combined path with `.resolve()` and verifies it is still within the resolved base directory.
3. Raises `ValueError` if either step fails.

All three call sites are updated to use the helper and translate `ValueError` into an HTTP 400 with a generic message (no path echoed back). This is a defense-in-depth approach: the basename step alone blocks traversal, and the post-resolve containment check protects against future call sites that might pass paths obtained from other sources (symlinks, etc.).

## What I tested

- Verified the three call sites are the only places where these three request fields are joined to base directories.
- Confirmed legitimate filenames (e.g., `voice.wav`) round-trip through `safe_resolve_within` unchanged in semantics — the resolved path equals `base_dir / "voice.wav"`.
- Confirmed traversal payloads (`../../etc/passwd`, `/etc/passwd`, `..\\..\\windows\\system.ini`) are reduced to their basename and either resolve inside `base_dir` (and then simply 404 because no such file exists there) or raise `ValueError` → HTTP 400.
- Diff is minimal: 17 lines changed in `server.py`, 26 lines added to `utils.py`, no behavioral change for valid inputs.

## Adversarial review

Before submitting I tried to disprove this finding. I checked whether FastAPI/Starlette or any upstream middleware in the project sanitizes path-like query/body fields — they don't; these are plain Pydantic string fields. I checked whether the endpoints are gated by auth — they aren't, and the default bind is `0.0.0.0`. I checked whether `Path.is_file()` followed by the audio loader would itself reject paths outside the base directory — it doesn't; both happily operate on absolute paths anywhere the process can read. The traversal is reachable and the fix is necessary.

## Notes

Happy to adjust the helper's location or naming, or to add unit tests if you'd like — let me know what fits the project's conventions.