### PR TITLE
Change GitHub Workflow to build containers

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -18,9 +18,54 @@ jobs:
       contents: read
       packages: write
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # NVIDIA CUDA 12.1
+          - dockerfile: Dockerfile
+            tag-suffix: nvidia
+            platforms: linux/amd64
+            build-args: RUNTIME=nvidia
+
+          # NVIDIA CUDA 12.8 Blackwell
+          - dockerfile: Dockerfile.cu128
+            tag-suffix: cu128
+            platforms: linux/amd64
+            build-args: RUNTIME=nvidia
+
+          # NVIDIA CUDA 13.0 Blackwell sm121 (ARM64)
+          - dockerfile: Dockerfile.cu130
+            tag-suffix: cu130
+            platforms: linux/arm64
+            build-args: RUNTIME=nvidia
+
+          # AMD ROCm
+          - dockerfile: Dockerfile.rocm
+            tag-suffix: rocm
+            platforms: linux/amd64
+            build-args: ""
+
+          # AMD Strix Halo ROCM
+          - dockerfile: Dockerfile.strixhalo
+            tag-suffix: strixhalo
+            platforms: linux/amd64
+            build-args: ""
+
+          # CPU only
+          - dockerfile: Dockerfile.cpu
+            tag-suffix: cpu
+            platforms: linux/amd64
+            build-args: ""
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -32,27 +77,27 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata (tags, labels) for Docker
+      - name: Extract metadata for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha,format=short
+            type=ref,event=branch,suffix=-${{ matrix.tag-suffix }}
+            type=ref,event=pr,suffix=-${{ matrix.tag-suffix }}
+            type=semver,pattern={{version}},suffix=-${{ matrix.tag-suffix }}
+            type=semver,pattern={{major}}.{{minor}},suffix=-${{ matrix.tag-suffix }}
+            type=sha,format=short,suffix=-${{ matrix.tag-suffix }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: ${{ matrix.platforms }}
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          platforms: linux/amd64
-          build-args: |
-            RUNTIME=nvidia 
+          build-args: ${{ matrix.build-args }}
+          cache-from: type=gha,scope=${{ matrix.tag-suffix }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.tag-suffix }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -71,6 +71,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -13,7 +13,6 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -27,45 +26,48 @@ jobs:
             tag-suffix: nvidia
             platforms: linux/amd64
             build-args: RUNTIME=nvidia
+            runner: ubuntu-latest
 
           # NVIDIA CUDA 12.8 Blackwell
           - dockerfile: Dockerfile.cu128
             tag-suffix: cu128
             platforms: linux/amd64
             build-args: RUNTIME=nvidia
+            runner: ubuntu-latest
 
           # NVIDIA CUDA 13.0 Blackwell sm121 (ARM64)
           - dockerfile: Dockerfile.cu130
             tag-suffix: cu130
             platforms: linux/arm64
             build-args: RUNTIME=nvidia
+            runner: ubuntu-24.04-arm
 
           # AMD ROCm
           - dockerfile: Dockerfile.rocm
             tag-suffix: rocm
             platforms: linux/amd64
             build-args: ""
+            runner: ubuntu-latest
 
-          # AMD Strix Halo ROCM
+          # AMD Strix Halo ROCm
           - dockerfile: Dockerfile.strixhalo
             tag-suffix: strixhalo
             platforms: linux/amd64
             build-args: ""
+            runner: ubuntu-latest
 
           # CPU only
           - dockerfile: Dockerfile.cpu
             tag-suffix: cpu
             platforms: linux/amd64
             build-args: ""
+            runner: ubuntu-latest
+
+    runs-on: ${{ matrix.runner }}
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Hi,
I just made a few tweaks since I noticed you haven't got any pre built Docker images.
This change will basically build all Docker containers for all Dockerfiles in your project through GitHub workflows.
Please also don't forget to set the visibility form your Docker images to public, of course only if this PR is interesting and you are willing to merge it.

Do also note that I haven't changed the compose files yet since I wasn't too sure if you want to Merge that.

Cheers and keep up the good work,
Christoph