### PR TITLE
Add language parameter support in OpenAI-compatible speech endpoint

### DIFF
--- a/server.py
+++ b/server.py
@@ -80,6 +80,7 @@ class OpenAISpeechRequest(BaseModel):
     response_format: Literal["wav", "opus", "mp3"] = "wav"  # Add "mp3"
     speed: float = 1.0
     seed: Optional[int] = None
+    language: Optional[str] = None
 
 
 # --- Logging Configuration ---
@@ -1447,7 +1448,7 @@ async def openai_speech_endpoint(request: OpenAISpeechRequest):
                 exaggeration=get_gen_default_exaggeration(),
                 cfg_weight=get_gen_default_cfg_weight(),
                 seed=chunk_seed,
-                language=get_gen_default_language(),
+                language=request.language or get_gen_default_language(),
             )
 
             if audio_tensor is None or sr is None:


### PR DESCRIPTION
This PR adds support for specifying the language parameter on the OpenAI-compatible /v1/audio/speech endpoint.

Previously, the endpoint always used the server default language through get_gen_default_language(), which made it difficult to use multilingual models in environments such as OpenWebUI where users may dynamically switch languages.

With this change, clients can now provide a per-request language value, while preserving the existing default behavior when the parameter is omitted.

Example:

{
  "model": "chatterbox-multilingual",
  "input": "Hallo wereld",
  "voice": "alloy",
  "language": "nl"
}

This improves compatibility with multilingual TTS workflows and OpenAI-compatible integrations.