### PR TITLE
[AMD] Add RDNA4 (gfx1201) Docker support 

### DIFF
--- a/Dockerfile.rdna4
+++ b/Dockerfile.rdna4
@@ -1,0 +1,52 @@
+FROM rocm/dev-ubuntu-22.04:latest
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV DEBIAN_FRONTEND=noninteractive
+ENV HF_HOME=/app/hf_cache
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libsndfile1 \
+    ffmpeg \
+    python3 \
+    python3-pip \
+    python3-dev \
+    python3-venv \
+    git \
+    rocm-ml-libraries \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+WORKDIR /app
+
+# Copy requirements - use strixhalo.txt for app deps, rdna4-init.txt for ROCm torch
+COPY requirements-rdna4-init.txt ./requirements-rdna4-init.txt
+COPY requirements-strixhalo.txt ./requirements-strixhalo.txt
+
+# Install in two steps: app deps first, then force-reinstall ROCm torch on top
+RUN python3 -m pip install --no-cache-dir --upgrade pip && \
+    pip3 install --no-cache-dir -r requirements-strixhalo.txt && \
+    python3 -m pip install --no-cache-dir --force-reinstall -r requirements-rdna4-init.txt
+
+# Patch s3tokenizer: cast numpy wav to float32 (numpy defaults to float64,
+# which causes float64 STFT → float64 mel → assertion failure with torch 2.9+)
+RUN sed -i \
+    's/wav = torch\.from_numpy(wav)$/wav = torch.from_numpy(wav).float()/' \
+    /usr/local/lib/python3.10/dist-packages/chatterbox/models/s3tokenizer/s3tokenizer.py && \
+    sed -i \
+    's/mel_spec = self\._mel_filters\.to(self\.device) @ magnitudes/mel_spec = self._mel_filters.to(self.device).to(magnitudes.dtype) @ magnitudes/' \
+    /usr/local/lib/python3.10/dist-packages/chatterbox/models/s3tokenizer/s3tokenizer.py
+
+# Patch voice_encoder: melspectrogram() returns float64 → LSTM requires float32
+RUN sed -i \
+    's/utt_embeds = self\.inference(mels\.to(self\.device),/utt_embeds = self.inference(mels.to(self.device).float(),/' \
+    /usr/local/lib/python3.10/dist-packages/chatterbox/models/voice_encoder/voice_encoder.py
+
+COPY . .
+RUN mkdir -p model_cache reference_audio outputs voices logs hf_cache
+
+EXPOSE 8004
+CMD ["python3", "server.py"]

--- a/Dockerfile.rdna4
+++ b/Dockerfile.rdna4
@@ -22,17 +22,21 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 
 WORKDIR /app
 
-# Copy requirements - use strixhalo.txt for app deps, rdna4-init.txt for ROCm torch
+# Self-contained RDNA4 requirements (no dependency on other requirements files)
 COPY requirements-rdna4-init.txt ./requirements-rdna4-init.txt
-COPY requirements-strixhalo.txt ./requirements-strixhalo.txt
+COPY requirements-rdna4.txt ./requirements-rdna4.txt
 
-# Install in two steps: app deps first, then force-reinstall ROCm torch on top
+# Install order mirrors Dockerfile.rocm: ROCm torch first, then app deps,
+# then chatterbox with --no-deps to prevent pip from replacing ROCm torch
 RUN python3 -m pip install --no-cache-dir --upgrade pip && \
-    pip3 install --no-cache-dir -r requirements-strixhalo.txt && \
-    python3 -m pip install --no-cache-dir --force-reinstall -r requirements-rdna4-init.txt
+    python3 -m pip install --no-cache-dir -r requirements-rdna4-init.txt && \
+    python3 -m pip install --no-cache-dir -r requirements-rdna4.txt && \
+    python3 -m pip install --no-cache-dir --no-deps git+https://github.com/devnen/chatterbox-v2.git@master s3tokenizer==0.3.0 onnx==1.16.0 && \
+    python3 -m pip install --no-cache-dir "protobuf>=4.25.0"
 
-# Patch s3tokenizer: cast numpy wav to float32 (numpy defaults to float64,
-# which causes float64 STFT → float64 mel → assertion failure with torch 2.9+)
+# Patches for torch 2.9+ compatibility (required when using ROCm 7.2 wheels):
+# s3tokenizer: numpy defaults to float64; cast to float32 to avoid
+# float64 STFT → float64 mel → assertion failure
 RUN sed -i \
     's/wav = torch\.from_numpy(wav)$/wav = torch.from_numpy(wav).float()/' \
     /usr/local/lib/python3.10/dist-packages/chatterbox/models/s3tokenizer/s3tokenizer.py && \
@@ -40,7 +44,7 @@ RUN sed -i \
     's/mel_spec = self\._mel_filters\.to(self\.device) @ magnitudes/mel_spec = self._mel_filters.to(self.device).to(magnitudes.dtype) @ magnitudes/' \
     /usr/local/lib/python3.10/dist-packages/chatterbox/models/s3tokenizer/s3tokenizer.py
 
-# Patch voice_encoder: melspectrogram() returns float64 → LSTM requires float32
+# voice_encoder: melspectrogram() returns float64 → LSTM requires float32
 RUN sed -i \
     's/utt_embeds = self\.inference(mels\.to(self\.device),/utt_embeds = self.inference(mels.to(self.device).float(),/' \
     /usr/local/lib/python3.10/dist-packages/chatterbox/models/voice_encoder/voice_encoder.py

--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ This server application enhances the underlying `chatterbox-tts` engine with the
 | NVIDIA DGX Spark / GB10 (sm_121) | Docker only | requirements-nvidia-cu130.txt (torch 2.10, CUDA 13.0) | 580+ |
 | AMD RX 6000/7000 (Linux) | `--rocm` | requirements-rocm.txt | ROCm 6.4+ |
 | AMD Strix Halo (Ryzen AI MAX+) | Docker only | requirements-strixhalo.txt (ROCm 7.2) | ROCm 7.2+ |
+| AMD RX 9000 series / RDNA4 (Linux) | Docker only | requirements-rdna4-init.txt (ROCm 7.2) | ROCm 7.2+ |
 | Apple Silicon (M1/M2/M3/M4) | Manual install | See Option 4 | macOS 12.3+ |
 
 ---
@@ -719,6 +720,27 @@ docker compose -f docker-compose-strixhalo.yml up -d
 ```
 
 The compose file sets `HSA_OVERRIDE_GFX_VERSION=11.0.0` and `HSA_XNACK=1` so the ROCm 7.2 wheels work on Strix Halo's GFX 11.5.0 silicon, and enables `TTS_BF16=on` for the throughput win on this hardware.
+
+---
+
+### **Option 6: AMD RDNA4 (RX 9070 / RX 9070 XT / R9700) Installation**
+
+> **Note:** For AMD **RDNA4 discrete GPUs** (RX 9070, RX 9070 XT, Radeon AI PRO R9700, gfx1201).
+> ROCm 6.1 wheels do **not** support gfx1201 — ROCm 7.2 is required. Standard discrete Radeon GPUs (RX 6000/7000) use Option 3.
+
+**Prerequisites:**
+- AMD RDNA4 GPU (RX 9070 / 9070 XT / R9700) on Linux
+- ROCm 7.2+ stack installed on the host (see [ROCm install guide](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/))
+- User in `video` and `render` groups: `sudo usermod -aG video,render $USER`
+
+**Using Docker (recommended):**
+```bash
+docker compose -f docker-compose-rdna4.yml up -d
+
+# Access the web UI at http://localhost:8004
+```
+
+The compose file sets `ROCBLAS_USE_HIPBLASLT=0` (required for stability on gfx1201) and enables `TTS_BF16=on` for throughput gain. gfx1201 is natively supported by ROCm 7.0+ — no `HSA_OVERRIDE_GFX_VERSION` needed.
 
 ---
 
@@ -1255,6 +1277,7 @@ lspci | grep VGA
 ```
 
 **Common GPU Architecture Mappings:**
+- **RX 9070 / 9070 XT / R9700 (gfx1201, RDNA4):** Natively supported by ROCm 7.0+. Use `docker-compose-rdna4.yml` — **no `HSA_OVERRIDE_GFX_VERSION` needed**. Setting it when the GPU is natively detected may cause crashes. Only set `HSA_OVERRIDE_GFX_VERSION=12.0.1` if using a tool that bundles its own older ROCm runtime without gfx1201 support (e.g. some ollama or LM Studio builds).
 - **Ryzen AI Max+ 395 (Strix Halo), RX 7900 XTX/XT, RX 7800 XT, RX 7700 XT:** gfx1100/gfx1150 → Use `HSA_OVERRIDE_GFX_VERSION=11.0.0`
 - **RX 6900 XT, RX 6800 XT, RX 6700 XT, RX 6600 XT:** gfx1030-1032 → Use `HSA_OVERRIDE_GFX_VERSION=10.3.0`
 - **RX 5700 XT, RX 5600 XT:** gfx1010 → Use `HSA_OVERRIDE_GFX_VERSION=10.3.0`

--- a/docker-compose-rdna4.yml
+++ b/docker-compose-rdna4.yml
@@ -31,7 +31,7 @@ services:
       - HF_TOKEN=YOUR_TOKEN_HERE
       - TTS_ENGINE_DEVICE=cuda
       # gfx1201 (RDNA4) is natively supported by ROCm 7.0+.
-      # HSA_OVERRIDE_GFX_VERSION is NOT set here — it is not needed with the ROCm 7.2
+      # HSA_OVERRIDE_GFX_VERSION is NOT set here — it is not needed with the ROCm 7.2.3
       # Docker image and may cause crashes if set when the GPU is already natively detected.
       # It is only needed for tools that bundle an older ROCm runtime without gfx1201 support
       # (e.g. some ollama/LM Studio builds).

--- a/docker-compose-rdna4.yml
+++ b/docker-compose-rdna4.yml
@@ -1,0 +1,44 @@
+services:
+  chatterbox-tts-server:
+    build:
+      context: .
+      dockerfile: Dockerfile.rdna4
+    ports:
+      - "${PORT:-8004}:8004"
+    volumes:
+      - ./config.yaml:/app/config.yaml
+      - ./voices:/app/voices
+      - ./reference_audio:/app/reference_audio
+      - ./outputs:/app/outputs
+      - ./logs:/app/logs
+      - hf_cache:/app/hf_cache
+
+    # --- ROCm GPU Access ---
+    devices:
+      - /dev/kfd
+      - /dev/dri
+    group_add:
+      - video
+      - render
+    ipc: host
+    shm_size: 8g
+    security_opt:
+      - seccomp=unconfined
+
+    restart: unless-stopped
+    environment:
+      - HF_HUB_ENABLE_HF_TRANSFER=1
+      - HF_TOKEN=YOUR_TOKEN_HERE
+      - TTS_ENGINE_DEVICE=cuda
+      # gfx1201 (RDNA4) is natively supported by ROCm 7.0+.
+      # HSA_OVERRIDE_GFX_VERSION is NOT set here — it is not needed with the ROCm 7.2
+      # Docker image and may cause crashes if set when the GPU is already natively detected.
+      # It is only needed for tools that bundle an older ROCm runtime without gfx1201 support
+      # (e.g. some ollama/LM Studio builds).
+      - ROCBLAS_USE_HIPBLASLT=0
+      - TTS_BF16=on
+      - TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1
+      - MIOPEN_FIND_MODE=FAST
+
+volumes:
+  hf_cache:

--- a/requirements-rdna4-init.txt
+++ b/requirements-rdna4-init.txt
@@ -1,18 +1,18 @@
 # requirements-rdna4-init.txt
 #
-# ROCm 7.2 PyTorch stack for RDNA4 (gfx1201 / RX 9070 / RX 9070 XT / R9700)
+# ROCm 7.2.3 PyTorch stack for RDNA4 (gfx1201 / RX 9070 / RX 9070 XT / R9700)
 #
 # NOTE: gfx1201 is natively supported by ROCm 7.0+ — no HSA_OVERRIDE needed.
 #       rocm6.1 wheels do NOT support gfx1201; ROCm 7.2+ is required.
 #
-# Uses AMD's official manylinux wheels (same build series as Strix Halo).
-# MUST be force-reinstalled AFTER requirements-strixhalo.txt to pin ROCm torch.
+# Uses AMD's official manylinux wheels from rocm-rel-7.2.3.
 #
 # Manual install:
-#   pip install -r requirements-strixhalo.txt
-#   pip install --force-reinstall -r requirements-rdna4-init.txt
+#   pip install -r requirements-rdna4-init.txt
+#   pip install -r requirements-rdna4.txt
+#   pip install --no-deps git+https://github.com/devnen/chatterbox-v2.git@master s3tokenizer==0.3.0 onnx==1.16.0
 
-https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/triton-3.5.1%2Brocm7.2.0.gita272dfa8-cp310-cp310-linux_x86_64.whl
-https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/torch-2.9.1%2Brocm7.2.0.lw.git7e1940d4-cp310-cp310-linux_x86_64.whl
-https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/torchvision-0.24.0%2Brocm7.2.0.gitb919bd0c-cp310-cp310-linux_x86_64.whl
-https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/torchaudio-2.9.0%2Brocm7.2.0.gite3c6ee2b-cp310-cp310-linux_x86_64.whl
+https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2.3/triton-3.5.1%2Brocm7.2.3.gita272dfa8-cp310-cp310-linux_x86_64.whl
+https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2.3/torch-2.9.1%2Brocm7.2.3.lw.gitebc02d69-cp310-cp310-linux_x86_64.whl
+https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2.3/torchvision-0.24.0%2Brocm7.2.3.gitb919bd0c-cp310-cp310-linux_x86_64.whl
+https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2.3/torchaudio-2.9.0%2Brocm7.2.3.gite3c6ee2b-cp310-cp310-linux_x86_64.whl

--- a/requirements-rdna4-init.txt
+++ b/requirements-rdna4-init.txt
@@ -1,0 +1,18 @@
+# requirements-rdna4-init.txt
+#
+# ROCm 7.2 PyTorch stack for RDNA4 (gfx1201 / RX 9070 / RX 9070 XT / R9700)
+#
+# NOTE: gfx1201 is natively supported by ROCm 7.0+ — no HSA_OVERRIDE needed.
+#       rocm6.1 wheels do NOT support gfx1201; ROCm 7.2+ is required.
+#
+# Uses AMD's official manylinux wheels (same build series as Strix Halo).
+# MUST be force-reinstalled AFTER requirements-strixhalo.txt to pin ROCm torch.
+#
+# Manual install:
+#   pip install -r requirements-strixhalo.txt
+#   pip install --force-reinstall -r requirements-rdna4-init.txt
+
+https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/triton-3.5.1%2Brocm7.2.0.gita272dfa8-cp310-cp310-linux_x86_64.whl
+https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/torch-2.9.1%2Brocm7.2.0.lw.git7e1940d4-cp310-cp310-linux_x86_64.whl
+https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/torchvision-0.24.0%2Brocm7.2.0.gitb919bd0c-cp310-cp310-linux_x86_64.whl
+https://repo.radeon.com/rocm/manylinux/rocm-rel-7.2/torchaudio-2.9.0%2Brocm7.2.0.gite3c6ee2b-cp310-cp310-linux_x86_64.whl

--- a/requirements-rdna4.txt
+++ b/requirements-rdna4.txt
@@ -1,0 +1,53 @@
+# requirements-rdna4.txt
+#
+# AMD RDNA4 (gfx1201) application dependencies for Chatterbox TTS Server.
+# For RX 9070 / RX 9070 XT / Radeon AI PRO R9700 on Linux with ROCm 7.2+.
+#
+# PyTorch (torch, torchaudio, torchvision, triton) are installed separately
+# via requirements-rdna4-init.txt using AMD's ROCm 7.2 manylinux wheels.
+# rocm6.1 wheels do NOT support gfx1201 — ROCm 7.2+ is required.
+#
+# Manual installation order:
+#   pip install -r requirements-rdna4-init.txt
+#   pip install -r requirements-rdna4.txt
+#   pip install --no-deps git+https://github.com/devnen/chatterbox-v2.git@master s3tokenizer==0.3.0 onnx==1.16.0
+#
+# The --no-deps flag on chatterbox-tts is critical: without it, pip will
+# replace the ROCm torch wheels with CPU-only versions from PyPI.
+
+# Chatterbox Dependencies (explicit, since --no-deps skips them)
+# NOTE: s3tokenizer and onnx are installed with --no-deps alongside chatterbox
+# to avoid protobuf version conflicts.
+conformer==0.3.2
+diffusers==0.29.0
+transformers==4.46.3
+einops>=0.7.0
+omegaconf==2.3.0
+resampy==0.4.3
+resemble-perth==1.0.1
+
+# Core Web Framework
+fastapi>=0.100.0,<0.116.0
+uvicorn[standard]>=0.27.0
+
+# Machine Learning & Audio
+numpy>=1.24.0
+soundfile>=0.12.0
+huggingface_hub>=0.20.0
+descript-audio-codec==1.0.0
+safetensors>=0.4.0
+
+# Configuration & Utilities
+pydantic>=2.0.0
+python-dotenv>=1.0.0
+Jinja2>=3.1.2,<3.2.0
+python-multipart>=0.0.5
+requests>=2.28.0
+PyYAML>=6.0
+tqdm>=4.65.0
+
+# Audio Post-processing
+pydub>=0.25.0
+praat-parselmouth>=0.4.0
+librosa>=0.10.0
+hf-transfer>=0.1.4


### PR DESCRIPTION
## Add RDNA4 (gfx1201) Docker support — RX 9070 / RX 9070 XT / Radeon AI PRO R9700

### Problem

The existing ROCm path (`requirements-rocm-init.txt`) pins `torch==2.5.1+rocm6.1`, which does **not** support the gfx1201 architecture (RDNA4). Users with RX 9070, RX 9070 XT, or Radeon AI PRO R9700 get `ROCm available: False` and have no working Docker path.

Related: #150

### Solution

A self-contained Docker path using AMD's official ROCm 7.2.3 manylinux wheels.

### Files added

| File | Purpose |
|------|---------|
| `requirements-rdna4-init.txt` | ROCm 7.2.3 PyTorch wheels (torch 2.9.1, torchaudio 2.9.0, torchvision 0.24.0, triton 3.5.1) |
| `requirements-rdna4.txt` | App dependencies — self-contained, no external requirements file dependencies |
| `Dockerfile.rdna4` | Ubuntu 22.04 base; install order mirrors `Dockerfile.rocm`; includes torch 2.9+ compatibility patches for s3tokenizer and voice_encoder |
| `docker-compose-rdna4.yml` | Sets `ROCBLAS_USE_HIPBLASLT=0`; enables `TTS_BF16=on` |

README changes: platform table, Option 6 install section, gfx1201 entry in AMD ROCm Support Details.

### Key design decision: `HSA_OVERRIDE_GFX_VERSION` is intentionally absent

gfx1201 is **natively supported** by ROCm 7.0+. Setting `HSA_OVERRIDE_GFX_VERSION` when the GPU is already natively detected causes crashes — confirmed by community reports and tested on our end. The variable is only needed for tools that bundle their own older ROCm runtime without gfx1201 support, not for system ROCm Docker images.

### Test results
- **Hardware:** AMD Radeon AI PRO R9700 (gfx1201 / RDNA4)
- **ROCm** 7.2.3

cmd:
```shell
docker run --rm \
  --device /dev/kfd --device /dev/dri \
  --group-add video --group-add render \
  -e ROCBLAS_USE_HIPBLASLT=0 \
  -e HIP_VISIBLE_DEVICES=0 \
  -e HF_HOME=/hf_cache \
  -e MIOPEN_FIND_MODE=FAST \
  -v /tmp/chatterbox-hf-cache:/hf_cache \
  -v /tmp/chatterbox-output:/output \
  chatterbox-rdna4:test2 \
  python3 -c "
import torch, soundfile as sf
from chatterbox.tts import ChatterboxTTS

print('PyTorch:', torch.__version__)
print('ROCm available:', torch.cuda.is_available())
if torch.cuda.is_available():
    print('GPU device ID:', hex(torch.cuda.current_device()))

model = ChatterboxTTS.from_pretrained(device='cuda')
print('Model loaded OK')

wav = model.generate('Validation test for AMD RDNA4 ROCm seven point two point three Docker image.')
sf.write('/output/test_rdna4_v2.wav', wav.squeeze().cpu().numpy(), model.sr)

import os
size = os.path.getsize('/output/test_rdna4_v2.wav')
print(f'Audio: {size} bytes, sr={model.sr}, shape={wav.shape}')
print('INFERENCE COMPLETE OK')
"
```
output:
```shell
--------------------------------------------------------------
PyTorch: 2.9.1+rocm7.2.3.gitebc02d69
ROCm available: True
GPU device ID: 0x0
loaded PerthNet (Implicit) at step 250,000
Model loaded OK
Sampling throughput:  ~61 it/s (peak, consistent with prior ~62 it/s)
Audio: 282284 bytes, sr=24000, shape=torch.Size([1, 141120])
INFERENCE COMPLETE OK
```
<img width="1844" height="898" alt="image" src="https://github.com/user-attachments/assets/d28d2066-60d3-4b8b-8612-72533e413b9b" />
