### PR TITLE
fix: remove duplicate code fence and heading in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,6 @@ python start.py --reinstall
 # Upgrade to latest version (keeps your hardware selection)
 python start.py --upgrade
 
-```bash
 # Install with verbose output for troubleshooting
 python start.py --reinstall --nvidia --verbose
 
@@ -386,9 +385,6 @@ python start.py --reinstall --portable
 
 # Force standard virtual environment (skip portable prompt)
 python start.py --no-portable
-```
-
-#### Subsequent Runs
 ```
 
 #### Subsequent Runs


### PR DESCRIPTION
Fixes a broken markdown code block in the Launcher Command-Line Options section. A second opening backtick fence was inserted without closing the first one, and the 'Subsequent Runs' heading appeared twice. This caused the example commands to render incorrectly.