### PR TITLE
fix: bound the voice conditioning cache to stop it exhausting VRAM

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -5,6 +5,7 @@ import gc
 import logging
 import os
 import random
+from collections import OrderedDict
 import numpy as np
 import torch
 from typing import Optional, Tuple
@@ -114,7 +115,43 @@ loaded_model_class_name: Optional[str] = None  # "ChatterboxTTS" or "ChatterboxT
 
 # Voice conditioning cache: avoids re-encoding the same voice file on every request.
 # Key: (resolved_path, file_mtime, exaggeration) — mtime invalidates if file changes.
-_conds_cache: dict = {}
+#
+# Bounded, because each entry pins GPU tensors for the process lifetime and this
+# was previously an unbounded dict cleared only by unload_model(). Measured on a
+# P106-100 (5.93 GiB) with chatterbox-turbo: cycling 28 reference voices grew
+# live tensors from 4.09 to 5.46 GiB and left 0.11 GiB of headroom, after which
+# 406 of 453 requests failed. The same load with one voice ran clean.
+#
+# This is not only a small-card concern. /upload_reference stores each uploaded
+# file under its own path, so every distinct voice a deployment ever serves mints
+# a permanent key — a larger card buys a higher ceiling, not a different outcome.
+#
+# CONDS_CACHE_MAX bounds the entry count. Measured cost is ~175 MB of VRAM per
+# entry (live tensors grew 1.37 GiB across exactly 8 cached voices), so this is a
+# far more expensive cache than it looks — budget it against free VRAM, not
+# against an entry count that sounds small.
+#
+# The default of 4 costs ~700 MB, which leaves a 6 GB card ~1.1 GiB for
+# generation after the 4.09 GiB model. On a 12 GB card 16+ is comfortable. Set 0
+# to disable caching and re-encode the voice on every request.
+_CONDS_CACHE_MAX: int = max(0, int(os.environ.get("CONDS_CACHE_MAX", "4")))
+_conds_cache: "OrderedDict[tuple, object]" = OrderedDict()
+
+
+def _conds_cache_store(key: tuple, conds) -> None:
+    """Insert under an LRU bound, evicting the least recently used entries.
+
+    Eviction drops the last reference to that entry's tensors; the caching
+    allocator reuses the freed blocks, so VRAM is recovered without an explicit
+    empty_cache() on the request path.
+    """
+    if _CONDS_CACHE_MAX == 0:
+        return
+    _conds_cache[key] = conds
+    _conds_cache.move_to_end(key)
+    while len(_conds_cache) > _CONDS_CACHE_MAX:
+        evicted_key, _ = _conds_cache.popitem(last=False)
+        logger.debug(f"Voice cache evicted (LRU, max={_CONDS_CACHE_MAX}): {evicted_key[0]}")
 
 
 def _conds_cache_key(path: str, exaggeration: float) -> tuple:
@@ -481,6 +518,9 @@ def synthesize(
             conds_key = _conds_cache_key(audio_prompt_path, ex_for_key)
             if conds_key in _conds_cache:
                 chatterbox_model.conds = _conds_cache[conds_key]
+                # Refresh recency, or the LRU bound would evict by insertion order
+                # and throw away the hottest voice under a rotating workload.
+                _conds_cache.move_to_end(conds_key)
                 effective_prompt = None  # conds already set, skip prepare_conditionals
                 logger.debug(f"Voice cache hit: {audio_prompt_path}")
 
@@ -509,7 +549,7 @@ def synthesize(
         # Store conds in cache after first compute for this voice.
         if conds_key is not None and effective_prompt is not None:
             if chatterbox_model.conds is not None:
-                _conds_cache[conds_key] = chatterbox_model.conds
+                _conds_cache_store(conds_key, chatterbox_model.conds)
                 logger.debug(f"Cached voice conditionals for: {audio_prompt_path}")
 
         # The ChatterboxTTS.generate method already returns a CPU tensor.

--- a/engine.py
+++ b/engine.py
@@ -5,6 +5,7 @@ import gc
 import logging
 import os
 import random
+import threading
 from collections import OrderedDict
 import numpy as np
 import torch
@@ -134,8 +135,40 @@ loaded_model_class_name: Optional[str] = None  # "ChatterboxTTS" or "ChatterboxT
 # The default of 4 costs ~700 MB, which leaves a 6 GB card ~1.1 GiB for
 # generation after the 4.09 GiB model. On a 12 GB card 16+ is comfortable. Set 0
 # to disable caching and re-encode the voice on every request.
-_CONDS_CACHE_MAX: int = max(0, int(os.environ.get("CONDS_CACHE_MAX", "4")))
+def _resolve_conds_cache_max() -> int:
+    """Read CONDS_CACHE_MAX, tolerating garbage rather than failing to import."""
+    raw = os.environ.get("CONDS_CACHE_MAX", "4").strip()
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        logger.warning(
+            f"CONDS_CACHE_MAX={raw!r} is not an integer; using the default of 4."
+        )
+        return 4
+
+
+_CONDS_CACHE_MAX: int = _resolve_conds_cache_max()
 _conds_cache: "OrderedDict[tuple, object]" = OrderedDict()
+
+# synthesize() runs concurrently: server.py dispatches it through
+# loop.run_in_executor(), so several threads can touch this cache at once.
+# Reads are two steps (look up, then refresh recency) and writes are three
+# (insert, refresh, evict), none of which are atomic — without this lock a
+# thread can evict a key between another thread's lookup and its use, raising
+# KeyError. The unbounded version could not hit this because nothing was ever
+# removed.
+_conds_cache_lock = threading.Lock()
+
+
+def _conds_cache_get(key: tuple):
+    """Return cached conds for `key` and mark it most-recently-used, else None."""
+    if _CONDS_CACHE_MAX == 0:
+        return None
+    with _conds_cache_lock:
+        conds = _conds_cache.get(key)
+        if conds is not None:
+            _conds_cache.move_to_end(key)
+        return conds
 
 
 def _conds_cache_store(key: tuple, conds) -> None:
@@ -147,11 +180,14 @@ def _conds_cache_store(key: tuple, conds) -> None:
     """
     if _CONDS_CACHE_MAX == 0:
         return
-    _conds_cache[key] = conds
-    _conds_cache.move_to_end(key)
-    while len(_conds_cache) > _CONDS_CACHE_MAX:
-        evicted_key, _ = _conds_cache.popitem(last=False)
-        logger.debug(f"Voice cache evicted (LRU, max={_CONDS_CACHE_MAX}): {evicted_key[0]}")
+    with _conds_cache_lock:
+        _conds_cache[key] = conds
+        _conds_cache.move_to_end(key)
+        while len(_conds_cache) > _CONDS_CACHE_MAX:
+            evicted_key, _ = _conds_cache.popitem(last=False)
+            logger.debug(
+                f"Voice cache evicted (LRU, max={_CONDS_CACHE_MAX}): {evicted_key[0]}"
+            )
 
 
 def _conds_cache_key(path: str, exaggeration: float) -> tuple:
@@ -516,11 +552,11 @@ def synthesize(
         if audio_prompt_path and hasattr(chatterbox_model, "conds"):
             ex_for_key = 0.0 if loaded_model_type == "turbo" else exaggeration
             conds_key = _conds_cache_key(audio_prompt_path, ex_for_key)
-            if conds_key in _conds_cache:
-                chatterbox_model.conds = _conds_cache[conds_key]
-                # Refresh recency, or the LRU bound would evict by insertion order
-                # and throw away the hottest voice under a rotating workload.
-                _conds_cache.move_to_end(conds_key)
+            # Single locked lookup that also refreshes recency — checking
+            # membership and then indexing would race with eviction.
+            cached_conds = _conds_cache_get(conds_key)
+            if cached_conds is not None:
+                chatterbox_model.conds = cached_conds
                 effective_prompt = None  # conds already set, skip prepare_conditionals
                 logger.debug(f"Voice cache hit: {audio_prompt_path}")
 
@@ -630,7 +666,8 @@ def reload_model() -> bool:
     MODEL_LOADED = False
     loaded_model_type = None
     loaded_model_class_name = None
-    _conds_cache.clear()
+    with _conds_cache_lock:
+        _conds_cache.clear()
     logger.info("Voice conditioning cache cleared.")
 
     # 3. Force Python Garbage Collection


### PR DESCRIPTION
## Summary

`_conds_cache` in `engine.py` is unbounded. It is keyed by `(path, mtime, exaggeration)` and cleared only by `unload_model()`, so every distinct reference voice a server ever handles pins GPU tensors for the lifetime of the process.

Each entry costs **~175 MB of VRAM**. On a 6 GB card that is enough to take the server from healthy to failing every request within an hour of ordinary traffic.

This adds an LRU bound (`CONDS_CACHE_MAX`, default 4) and refreshes recency on cache hits so a rotating voice workload evicts least-recently-used rather than by insertion order.

## How it fails today

Observed on a live deployment: a worker served correctly for ~45 minutes, then began returning 500 for every generation with `CUDA out of memory: Tried to allocate 2.00 MiB`, while `/api/model-info` still reported `{"loaded": true}` and `/docs` still returned 200.

The tell is the size of the failing allocation. Failing to obtain 2 MiB while holding ~260 MB reserved-but-free is not an oversized model, it is a cache that has eaten the working headroom.

## Measurements

P106-100 (5.93 GiB usable), `chatterbox-turbo`, three 10-minute soaks cycling 28 reference voices at ~45 req/min with text lengths varying 40–520 chars:

| `CONDS_CACHE_MAX` | requests | failed | live tensors at end | headroom |
|---|---|---|---|---|
| unbounded (today) | 453 | **406 (90%)** | 5.46 GiB | 0.11 GiB |
| 2 | 89 | 1 (1.1%) | 4.58 GiB | 0.10–0.49 GiB |
| 0 | 88 | **0** | 4.37 GiB | 0.28–0.40 GiB |

Model footprint on a fresh load is 4.09 GiB, so the +1.37 GiB of retained tensors is exactly 8 cached voices × ~175 MB.

Two controls confirm the cache is the cause rather than allocator fragmentation:

- **Same load, one voice, unbounded cache: 50/50 requests succeeded**, live tensors flat at 4.34 GiB. Voice variety is the variable, not request volume or text length.
- `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` alone does **not** fix it. It helps a separate fragmentation effect (reserved memory grows while live tensors stay flat), but it cannot free tensors the cache still references.

## Cost of a smaller cache

A miss only re-encodes the reference audio. Measured on an RTX 4070 against a 3.8 MB reference:

| request | miss | hit | delta |
|---|---|---|---|
| 84 chars | 1.23s | 1.09s | +0.14s (+13%) |
| 240 chars | 3.30s | 3.32s | within noise |

It is a **fixed** per-request cost that does not scale with output length, so it is a small percentage on anything but very short requests. Cheap relative to 175 MB of VRAM per entry.

## Choosing the default

4 entries (~700 MB) leaves a 6 GB card ~1.1 GiB for generation after the model. It is deliberately conservative: an oversized cache takes a card out of service entirely, while an undersized one costs ~0.14s on a miss. Deployments with VRAM to spare can raise it — 16 is comfortable on 12 GB — and orchestration layers can size it per device from `torch.cuda.mem_get_info()` at launch.

Happy to change the default, or gate the whole thing behind an opt-in flag if you would rather not alter behaviour for existing users. I would suggest against leaving it unbounded even so, since the failure is silent and looks like a hung GPU rather than a cache problem.

## Testing

- LRU eviction, recency refresh on hit, re-store of an existing key, and `CONDS_CACHE_MAX=0` verified directly against the eviction logic.
- Soaks above run against the real model on real hardware.
- No API change; default behaviour differs only once a process has cached more than 4 distinct voices.
