### PR TITLE
Load the model on demand and unload it after 20 idle minutes

### DIFF
--- a/config.py
+++ b/config.py
@@ -49,6 +49,13 @@ DEFAULT_CONFIG: Dict[str, Any] = {
         "log_file_backup_count": 5,  # Number of backup log files to keep.
         "ssl_certfile": None,  # Path to SSL certificate file for HTTPS. None = HTTP only.
         "ssl_keyfile": None,  # Path to SSL private key file for HTTPS. None = HTTP only.
+        # Defer model loading until the first TTS request instead of loading at
+        # startup. Keeps VRAM free on an idle server; the first request pays the
+        # load cost. Set False to restore eager startup loading.
+        "lazy_load_model": True,
+        # Minutes of inactivity after which the model is unloaded and its VRAM
+        # released. The next request reloads it automatically. 0 disables.
+        "model_idle_timeout_minutes": 20,
     },
     "model": {  # Added section for model source configuration
         "repo_id": "chatterbox-turbo",  # UPDATED: Default to Turbo model

--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,11 @@ server:
   log_file_path: logs/tts_server.log
   log_file_max_size_mb: 10
   log_file_backup_count: 5
+  # Load the model on the first request rather than at startup.
+  lazy_load_model: true
+  # Unload the model after this many idle minutes, freeing its VRAM. The next
+  # request reloads it automatically. Set to 0 to keep the model resident.
+  model_idle_timeout_minutes: 20
 model:
   repo_id: chatterbox-turbo
 tts_engine:

--- a/engine.py
+++ b/engine.py
@@ -5,6 +5,9 @@ import gc
 import logging
 import os
 import random
+import threading
+import time
+from contextlib import contextmanager
 import numpy as np
 import torch
 from typing import Optional, Tuple
@@ -115,6 +118,15 @@ loaded_model_class_name: Optional[str] = None  # "ChatterboxTTS" or "ChatterboxT
 # Voice conditioning cache: avoids re-encoding the same voice file on every request.
 # Key: (resolved_path, file_mtime, exaggeration) — mtime invalidates if file changes.
 _conds_cache: dict = {}
+
+# --- Model lifecycle state ---
+# Guards every load/unload transition so a lazy load triggered by one request
+# cannot race another, and so the idle monitor never unloads mid-generation.
+_lifecycle_lock = threading.RLock()
+_active_requests: int = 0  # in-flight syntheses; the idle monitor waits these out
+_last_used_at: float = time.monotonic()
+_idle_monitor_thread: Optional[threading.Thread] = None
+_idle_timeout_seconds: float = 0.0
 
 
 def _conds_cache_key(path: str, exaggeration: float) -> tuple:
@@ -263,6 +275,8 @@ def get_model_info() -> dict:
         "supported_languages": (
             SUPPORTED_LANGUAGES if loaded_model_type == "multilingual" else {"en": "English"}
         ),
+        # Lifecycle detail so the UI can show residency and the unload countdown.
+        "idle": get_idle_status(),
     }
 
 
@@ -413,6 +427,9 @@ def load_model() -> bool:
             MODEL_LOADED = False
             return False
 
+        # Start the idle clock from the moment the weights land, so a model that
+        # loads and is never used still gets released.
+        _refresh_last_used()
         return True
 
     except Exception as e:
@@ -424,7 +441,155 @@ def load_model() -> bool:
         return False
 
 
-def synthesize(
+def _refresh_last_used() -> None:
+    """Reset the idle clock. Called on every load and every synthesis."""
+    global _last_used_at
+    _last_used_at = time.monotonic()
+
+
+def ensure_model_loaded() -> bool:
+    """Load the configured model if it is not currently resident.
+
+    This is what lets generation survive a lazy start or an idle unload: instead
+    of failing with "model not loaded", the caller pays the load cost once. Safe
+    under concurrency — the lock means a second caller waits for the first
+    caller's load rather than starting a competing one.
+
+    Returns:
+        bool: True if a model is resident when this returns.
+    """
+    with _lifecycle_lock:
+        if MODEL_LOADED and chatterbox_model is not None:
+            _refresh_last_used()
+            return True
+
+        logger.info("No model resident — loading on demand...")
+        started = time.monotonic()
+        success = load_model()
+        if success:
+            logger.info(
+                f"On-demand load completed in {time.monotonic() - started:.1f}s."
+            )
+            _refresh_last_used()
+        else:
+            logger.error("On-demand model load failed.")
+        return success
+
+
+@contextmanager
+def model_in_use():
+    """Mark a synthesis as in flight so the idle monitor leaves the model alone.
+
+    The counter is what stops the monitor unloading the weights out from under a
+    request that is midway through generating.
+    """
+    global _active_requests
+    with _lifecycle_lock:
+        _active_requests += 1
+        _refresh_last_used()
+    try:
+        yield
+    finally:
+        with _lifecycle_lock:
+            _active_requests = max(0, _active_requests - 1)
+            _refresh_last_used()
+
+
+def _idle_monitor_loop(check_interval: float) -> None:
+    """Background loop that releases the model once it has gone unused."""
+    while True:
+        time.sleep(check_interval)
+        try:
+            with _lifecycle_lock:
+                if not MODEL_LOADED or _active_requests > 0:
+                    continue
+                idle_for = time.monotonic() - _last_used_at
+                if idle_for < _idle_timeout_seconds:
+                    continue
+                logger.info(
+                    f"Model idle for {idle_for / 60:.1f} min "
+                    f"(timeout {_idle_timeout_seconds / 60:.0f} min) — unloading to free VRAM."
+                )
+                unload_model()
+        except Exception:
+            # A failure here must not kill the thread, or idle unloading would
+            # silently stop working for the rest of the process's life.
+            logger.error("Idle monitor iteration failed.", exc_info=True)
+
+
+def start_idle_monitor(timeout_minutes: float, check_interval: float = 30.0) -> bool:
+    """Start (or retune) the background idle-unload monitor.
+
+    Args:
+        timeout_minutes: Idle minutes before the model is released. 0 disables.
+        check_interval: Seconds between checks.
+
+    Returns:
+        bool: True if the monitor is running when this returns.
+    """
+    global _idle_monitor_thread, _idle_timeout_seconds
+
+    with _lifecycle_lock:
+        _idle_timeout_seconds = max(0.0, float(timeout_minutes)) * 60.0
+
+        if _idle_timeout_seconds <= 0:
+            logger.info("Idle model unloading is disabled (timeout set to 0).")
+            return False
+
+        if _idle_monitor_thread is not None and _idle_monitor_thread.is_alive():
+            logger.info(
+                f"Idle monitor already running; timeout updated to {timeout_minutes:g} min."
+            )
+            return True
+
+        _idle_monitor_thread = threading.Thread(
+            target=_idle_monitor_loop,
+            args=(check_interval,),
+            name="model-idle-monitor",
+            daemon=True,
+        )
+        _idle_monitor_thread.start()
+        logger.info(
+            f"Idle monitor started: model unloads after {timeout_minutes:g} min of inactivity."
+        )
+        return True
+
+
+def get_idle_status() -> dict:
+    """Idle/lifecycle detail for the UI and API."""
+    with _lifecycle_lock:
+        idle_for = time.monotonic() - _last_used_at
+        countdown = None
+        if MODEL_LOADED and _idle_timeout_seconds > 0 and _active_requests == 0:
+            countdown = max(0.0, round(_idle_timeout_seconds - idle_for, 1))
+        return {
+            "idle_timeout_minutes": round(_idle_timeout_seconds / 60.0, 2),
+            "idle_seconds": round(idle_for, 1) if MODEL_LOADED else None,
+            "seconds_until_unload": countdown,
+            "active_requests": _active_requests,
+        }
+
+
+def synthesize(*args, **kwargs) -> Tuple[Optional[torch.Tensor], Optional[int]]:
+    """
+    Synthesizes audio from text. See `_synthesize_impl` for the parameters.
+
+    This wrapper holds the in-use count for the whole generation, which stops the
+    idle monitor unloading the weights mid-request, and reloads the model if it
+    was released between the caller's readiness check and this call.
+    """
+    with model_in_use():
+        if not MODEL_LOADED or chatterbox_model is None:
+            logger.info(
+                "Model was not resident at synthesis time — loading it now."
+            )
+            if not ensure_model_loaded():
+                logger.error("Cannot synthesize: on-demand model load failed.")
+                return None, None
+        return _synthesize_impl(*args, **kwargs)
+
+
+def _synthesize_impl(
     text: str,
     audio_prompt_path: Optional[str] = None,
     temperature: float = 0.8,
@@ -525,9 +690,24 @@ def unload_model() -> bool:
     Unloads the current model and releases all GPU memory.
     Does NOT reload the model - use reload_model() for that.
 
+    Refuses while a synthesis is in flight, so neither the idle monitor nor a
+    manual /api/unload can pull the weights out from under an active request.
+
     Returns:
         bool: True if the model was unloaded successfully, False otherwise.
     """
+    with _lifecycle_lock:
+        if _active_requests > 0:
+            logger.warning(
+                f"Unload requested while {_active_requests} synthesis request(s) are in "
+                "flight. Skipping unload."
+            )
+            return False
+        return _unload_model_unlocked()
+
+
+def _unload_model_unlocked() -> bool:
+    """Unload implementation. Callers must hold `_lifecycle_lock`."""
     global chatterbox_model, MODEL_LOADED, model_device, loaded_model_type, loaded_model_class_name
 
     logger.info("Initiating model unload sequence...")
@@ -573,9 +753,28 @@ def reload_model() -> bool:
     based on the current configuration. Used for hot-swapping models
     without restarting the server process.
 
+    Also the path behind "Reload Model" in the UI: it rebuilds whatever the
+    config currently names, so re-applying the model you are already on is a
+    single action rather than a switch away and back.
+
     Returns:
         bool: True if the new model loaded successfully, False otherwise.
     """
+    with _lifecycle_lock:
+        if _active_requests > 0:
+            logger.warning(
+                f"Reload requested while {_active_requests} synthesis request(s) are in "
+                "flight. Skipping reload."
+            )
+            return False
+        result = _reload_model_unlocked()
+        if result:
+            _refresh_last_used()
+        return result
+
+
+def _reload_model_unlocked() -> bool:
+    """Reload implementation. Callers must hold `_lifecycle_lock`."""
     global chatterbox_model, MODEL_LOADED, model_device, loaded_model_type, loaded_model_class_name, _conds_cache
 
     logger.info("Initiating model hot-swap/reload sequence...")

--- a/server.py
+++ b/server.py
@@ -153,12 +153,32 @@ async def lifespan(app: FastAPI):
         for p in paths_to_ensure:
             p.mkdir(parents=True, exist_ok=True)
 
-        if not engine.load_model():
+        lazy_load = config_manager.get_bool("server.lazy_load_model", True)
+        idle_timeout_minutes = config_manager.get_float(
+            "server.model_idle_timeout_minutes", 20.0
+        )
+
+        model_ready = True
+        if lazy_load:
+            logger.info(
+                "Lazy loading enabled: the model will load on the first TTS request, "
+                "leaving VRAM free until then."
+            )
+        elif not engine.load_model():
+            model_ready = False
             logger.critical(
                 "CRITICAL: TTS Model failed to load on startup. Server might not function correctly."
             )
         else:
             logger.info("TTS Model loaded successfully via engine.")
+
+        # The idle monitor runs regardless of how the model got loaded — it only
+        # acts once something is resident and has gone unused.
+        engine.start_idle_monitor(idle_timeout_minutes)
+
+        # Open the browser whenever the server itself came up. Previously this was
+        # gated on a successful eager load, which never happens in lazy mode.
+        if model_ready:
             host_address = get_host()
             server_port = get_port()
             browser_thread = threading.Thread(
@@ -617,6 +637,15 @@ async def unload_model_endpoint():
     logger.info("Request received for /api/unload (Model Unload).")
 
     try:
+        active = engine.get_idle_status().get("active_requests", 0)
+        if active > 0:
+            # Not a failure — the model is busy. Distinguish it so callers can retry.
+            message = (
+                f"{active} synthesis request(s) in flight; model left loaded. Retry once idle."
+            )
+            logger.info(f"Unload skipped: {message}")
+            raise HTTPException(status_code=409, detail=message)
+
         success = engine.unload_model()
 
         if success:
@@ -879,12 +908,19 @@ async def custom_tts_endpoint(
     )
     perf_monitor.record("TTS request received")
 
+    # Load on demand rather than rejecting the request. Covers both a lazy start
+    # and a model that was released after sitting idle.
     if not engine.MODEL_LOADED:
-        logger.error("TTS request failed: Model not loaded.")
+        logger.info("TTS request arrived with no model resident — loading it now.")
+    if not await asyncio.get_running_loop().run_in_executor(
+        None, engine.ensure_model_loaded
+    ):
+        logger.error("TTS request failed: model could not be loaded.")
         raise HTTPException(
             status_code=503,
-            detail="TTS engine model is not currently loaded or available.",
+            detail="TTS engine model could not be loaded. Check server logs for details.",
         )
+    perf_monitor.record("Model ready")
 
     logger.info(
         f"Received /tts request: mode='{request.voice_mode}', format='{request.output_format}'"
@@ -1411,11 +1447,15 @@ async def openai_speech_endpoint(request: OpenAISpeechRequest):
             status_code=404, detail=f"Voice file '{request.voice}' not found."
         )
 
-    # Check if the TTS model is loaded
+    # Load on demand rather than rejecting the request (lazy start or idle unload).
     if not engine.MODEL_LOADED:
+        logger.info("Speech request arrived with no model resident — loading it now.")
+    if not await asyncio.get_running_loop().run_in_executor(
+        None, engine.ensure_model_loaded
+    ):
         raise HTTPException(
             status_code=503,
-            detail="TTS engine model is not currently loaded or available.",
+            detail="TTS engine model could not be loaded. Check server logs for details.",
         )
 
     try:

--- a/ui/script.js
+++ b/ui/script.js
@@ -333,17 +333,7 @@ document.addEventListener('DOMContentLoaded', async function () {
         }
 
         // Update model status indicator
-        if (modelStatusIndicator && modelStatusText) {
-            if (modelInfo.loaded) {
-                modelStatusIndicator.className = 'status-dot success';
-                modelStatusText.textContent = `${modelInfo.class_name} loaded on ${modelInfo.device}`;
-                modelStatusText.className = 'model-status__text success';
-            } else {
-                modelStatusIndicator.className = 'status-dot error';
-                modelStatusText.textContent = 'Model not loaded';
-                modelStatusText.className = 'model-status__text error';
-            }
-        }
+        updateModelStatusLine(modelInfo);
 
         // Update model selector dropdown to match loaded model
         if (modelSelect && !modelChangesPending) {
@@ -378,6 +368,13 @@ document.addEventListener('DOMContentLoaded', async function () {
             exaggerationGroup?.classList.remove('hidden');
             cfgWeightGroup?.classList.remove('hidden');
         }
+
+        // The apply/reload control is always available: with nothing resident it
+        // loads, and with a model resident it restarts it in place.
+        if (applyModelBtn) {
+            applyModelBtn.classList.remove('hidden');
+        }
+        updateApplyModelBtnLabel();
 
         // Refresh presets to filter based on current model type
         populatePresets();
@@ -488,14 +485,97 @@ document.addEventListener('DOMContentLoaded', async function () {
         } else {
             modelChangesPending = false;
 
-            // Hide the apply button
+            // Keep the button available even when the selection is unchanged, so
+            // the current model can be reloaded in one step. Hiding it here used
+            // to force a switch to another model and back to restart the one you
+            // were already on.
             if (applyModelBtn) {
-                applyModelBtn.classList.add('hidden');
+                applyModelBtn.classList.remove('hidden');
             }
 
             // Restore status from current model info
             updateModelUI(currentModelInfo);
         }
+
+        updateApplyModelBtnLabel();
+    }
+
+    // Status line only — safe to call on a timer, unlike updateModelUI which
+    // re-renders presets and model-specific controls.
+    function updateModelStatusLine(modelInfo) {
+        if (!modelStatusIndicator || !modelStatusText || !modelInfo) return;
+
+        // A pending model change owns this line until it is applied.
+        if (modelChangesPending) return;
+
+        if (modelInfo.loaded) {
+            let statusText = `${modelInfo.class_name} loaded on ${modelInfo.device}`;
+            const countdown = modelInfo.idle?.seconds_until_unload;
+            if (typeof countdown === 'number') {
+                statusText += ` · unloads in ${formatIdleCountdown(countdown)}`;
+            }
+            modelStatusIndicator.className = 'status-dot success';
+            modelStatusText.textContent = statusText;
+            modelStatusText.className = 'model-status__text success';
+        } else {
+            // Nothing resident is the normal resting state now, not an error —
+            // generating loads the model automatically.
+            modelStatusIndicator.className = 'status-dot warning';
+            modelStatusText.textContent = 'Not loaded — will load on next generation';
+            modelStatusText.className = 'model-status__text warning';
+        }
+    }
+
+    // Keeps the status line and countdown honest while the model idles out from
+    // under an open page.
+    async function refreshModelStatus() {
+        if (document.hidden) return;
+        try {
+            const response = await fetch(`${API_BASE_URL}/api/model-info`);
+            if (!response.ok) return;
+            const info = await response.json();
+            if (!info) return;
+
+            const wasLoaded = currentModelInfo?.loaded;
+            currentModelInfo = info;
+            updateModelStatusLine(info);
+
+            // Residency flipped, so the button's job changed with it.
+            if (wasLoaded !== info.loaded) {
+                updateApplyModelBtnLabel();
+            }
+        } catch (error) {
+            // Server may be mid-restart during a model swap; retry on the next tick.
+        }
+    }
+
+    function formatIdleCountdown(seconds) {
+        const total = Math.max(0, Math.round(seconds));
+        const mins = Math.floor(total / 60);
+        const secs = total % 60;
+        if (mins && secs) return `${mins}m ${secs}s`;
+        return mins ? `${mins}m` : `${secs}s`;
+    }
+
+    // The button does double duty: apply a pending change, or reload the model
+    // that is already selected. Label it for whichever case applies.
+    function updateApplyModelBtnLabel() {
+        if (!applyModelBtn || applyModelBtn.disabled) return;
+
+        const icon = `
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-1">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
+            </svg>
+        `;
+        const label = modelChangesPending
+            ? 'Apply &amp; Restart'
+            : (currentModelInfo?.loaded ? 'Reload Model' : 'Load Model');
+        applyModelBtn.innerHTML = `${icon}${label}`;
+        applyModelBtn.title = modelChangesPending
+            ? 'Switch to the selected model'
+            : (currentModelInfo?.loaded
+                ? 'Restart the model that is already loaded'
+                : 'Load the selected model now instead of waiting for the first request');
     }
 
 
@@ -566,15 +646,10 @@ document.addEventListener('DOMContentLoaded', async function () {
             console.error('Error applying model change:', error);
             showNotification(`Error: ${error.message}`, 'error');
 
-            // Re-enable button
+            // Re-enable button, relabelled for whichever job it now has
             if (applyModelBtn) {
                 applyModelBtn.disabled = false;
-                applyModelBtn.innerHTML = `
-                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4 mr-1">
-                        <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99" />
-                    </svg>
-                    Apply & Restart
-                `;
+                updateApplyModelBtnLabel();
             }
         }
     }
@@ -757,6 +832,9 @@ document.addEventListener('DOMContentLoaded', async function () {
         if (applyModelBtn) {
             applyModelBtn.addEventListener('click', applyModelChange);
         }
+
+        // Poll residency so an idle unload is reflected without a page refresh.
+        setInterval(refreshModelStatus, 15000);
 
         // NEW: Tag button listeners
         tagButtons.forEach(button => {


### PR DESCRIPTION
The server loaded a checkpoint during startup and held its VRAM for the life of the process, so an idle server sat on ~3GB it was not using. The only way back to an empty GPU was POST /api/unload, after which every TTS request failed with a 503 until someone hot-swapped the model by hand.

Engine lifecycle:

- Add _lifecycle_lock, an in-flight request counter and a last-used timestamp. Every load/unload transition now takes the lock, so a lazy load triggered by one request cannot race another.
- ensure_model_loaded() loads the configured model if none is resident and is safe to call concurrently: the second caller waits on the first caller's load rather than starting a competing one.
- model_in_use() marks a synthesis as in flight. unload_model() and reload_model() refuse while the count is non-zero, so neither the idle monitor nor a manual unload can pull weights out from under a request.
- start_idle_monitor() runs a daemon thread that releases the model once it has gone unused for the configured window. Failures inside the loop are caught, since letting the thread die would silently stop idle unloading for the rest of the process's life.
- synthesize() is now a thin wrapper that holds the in-use count for the whole generation and reloads the model if it was released between the caller's readiness check and the call itself.

Server:

- Skip the startup load when server.lazy_load_model is set (default on), and start the idle monitor regardless of how the model got loaded. Browser auto-open no longer depends on a successful eager load, which never happens in lazy mode.
- /tts and /v1/audio/speech call ensure_model_loaded() instead of rejecting the request with "model is not currently loaded". A 503 now means the load genuinely failed, not that nothing was resident.
- /api/unload returns 409 rather than 500 when a synthesis is in flight, so callers can tell "busy, retry" from "broken".

UI:

- The apply button stays visible when the selection matches the resident model, relabelled "Reload Model" (or "Load Model" when nothing is resident). Restarting the current model was previously impossible without switching to another model and back.
- The status line reports the unload countdown, and an unloaded engine reads "will load on next generation" instead of an error, because nothing resident is now the normal resting state.
- Poll /api/model-info every 15s so an idle unload shows up without a page refresh. The poll updates only the status line, not the full model UI, to avoid re-rendering presets on a timer.

Config: server.lazy_load_model (default true) and
server.model_idle_timeout_minutes (default 20, 0 disables).

Verified against stubbed models -- 30 checks covering lazy start, on-demand load at synthesis, idle release, the in-flight guards and the countdown. Not yet exercised on a GPU, so the claim that VRAM returns to the driver is still untested on real hardware.