### PR TITLE
Fix GPU memory leak in voice conditioning cache

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -487,7 +487,7 @@ def synthesize(
         # Call the core model's generate method.
         # autocast promotes float32 inputs to bfloat16 to match T3/S3Gen weights,
         # keeping numerically sensitive ops (softmax, norms) in float32 automatically.
-        with torch.autocast("cuda", dtype=torch.bfloat16, enabled=BF16_ENABLED):
+        with torch.inference_mode(), torch.autocast("cuda", dtype=torch.bfloat16, enabled=BF16_ENABLED):
             if loaded_model_type == "multilingual":
                 wav_tensor = chatterbox_model.generate(
                     text=text,


### PR DESCRIPTION
`prepare_conditionals` runs inside `generate` on a cache miss without a grad guard, so each entry stored in `_conds_cache` carries the autograd graph of the reference encoders. On CUDA that is roughly 200 MB per distinct voice, held for the life of the process.

Measured on an RTX 4070 8 GB with the cu128 image: 6 voices, +1341 MB allocated (`embedding.grad_fn` set); the same 6 under `torch.inference_mode`, +1 MB. Around 20 distinct voices produced `CUDA out of memory ... 7.39 GiB is allocated by PyTorch`.

Fix: wrap the generate call in `torch.inference_mode()`. With this change, 26 new voices plus long text went from 4414 MB to 5256 MB and stayed flat.
